### PR TITLE
ADD: implements StoredVerkleTrie

### DIFF
--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/StoredVerkleTrie.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/StoredVerkleTrie.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Besu Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.trie.verkle;
+
+import org.hyperledger.besu.ethereum.trie.verkle.factory.NodeFactory;
+import org.hyperledger.besu.ethereum.trie.verkle.node.NullNode;
+
+import org.apache.tuweni.bytes.Bytes;
+
+public class StoredVerkleTrie<K extends Bytes, V extends Bytes> extends SimpleVerkleTrie<K, V> {
+  protected final NodeFactory<V> nodeFactory;
+
+  /**
+   * Create a trie.
+   *
+   * @param nodeFactory The {@link StoredNodeFactory} to retrieve node.
+   */
+  public StoredVerkleTrie(final NodeFactory<V> nodeFactory) {
+    super(nodeFactory.retrieve(Bytes.EMPTY, null).orElse(NullNode.instance()));
+    this.nodeFactory = nodeFactory;
+  }
+}

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/exceptions/VerkleTrieException.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/exceptions/VerkleTrieException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Besu Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.trie.verkle.exceptions;
+
+import org.apache.tuweni.bytes.Bytes;
+
+public class VerkleTrieException extends RuntimeException {
+  private Bytes location;
+
+  public VerkleTrieException(final String message) {
+    super(message);
+  }
+
+  public VerkleTrieException(final String message, final Bytes location) {
+    super(message);
+    this.location = location;
+  }
+
+  public VerkleTrieException(final String message, final Exception cause) {
+    super(message, cause);
+  }
+
+  public Bytes getLocation() {
+    return location;
+  }
+}

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/factory/StoredNodeFactory.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/factory/StoredNodeFactory.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.trie.verkle.node.BranchNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.LeafNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.Node;
 import org.hyperledger.besu.ethereum.trie.verkle.node.NullNode;
+import org.hyperledger.besu.ethereum.trie.verkle.node.StoredNode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -94,8 +95,7 @@ public class StoredNodeFactory<V> implements NodeFactory<V> {
     int nChild = BranchNode.maxChild();
     ArrayList<Node<V>> children = new ArrayList<Node<V>>(nChild);
     for (int i = 0; i < nChild; i++) {
-      Optional<Node<V>> child = retrieve(Bytes.concatenate(location, Bytes.of(i)), hash);
-      children.add(child.orElse(NullNode.instance()));
+      children.add(new StoredNode<>(this, Bytes.concatenate(location, Bytes.of(i))));
     }
     return new BranchNode<V>(location, hash, path, children);
   }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StoredNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StoredNode.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Besu Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.trie.verkle.node;
+
+import org.hyperledger.besu.ethereum.trie.verkle.factory.NodeFactory;
+import org.hyperledger.besu.ethereum.trie.verkle.visitor.NodeVisitor;
+import org.hyperledger.besu.ethereum.trie.verkle.visitor.PathNodeVisitor;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class StoredNode<V> implements Node<V> {
+  private final Bytes location;
+  private final NodeFactory<V> nodeFactory;
+  private Optional<Node<V>> loadedNode;
+
+  private boolean dirty = true; // not persisted
+
+  public StoredNode(final NodeFactory<V> nodeFactory, final Bytes location) {
+    this.location = location;
+    this.nodeFactory = nodeFactory;
+    loadedNode = Optional.empty();
+  }
+
+  /**
+   * Accept a visitor to perform operations on the node based on a provided path.
+   *
+   * @param visitor The visitor to accept.
+   * @param path The path associated with a node.
+   * @return The result of visitor's operation.
+   */
+  @Override
+  public Node<V> accept(PathNodeVisitor<V> visitor, Bytes path) {
+    final Node<V> node = load();
+    return node.accept(visitor, path);
+  }
+
+  /**
+   * Accept a visitor to perform operations on the node.
+   *
+   * @param visitor The visitor to accept.
+   * @return The result of the visitor's operation.
+   */
+  @Override
+  public Node<V> accept(NodeVisitor<V> visitor) {
+    final Node<V> node = load();
+    return node.accept(visitor);
+  }
+
+  /**
+   * Get the path associated with the node.
+   *
+   * @return The path of the node.
+   */
+  @Override
+  public Bytes getPath() {
+    final Node<V> node = load();
+    return node.getPath();
+  }
+  ;
+
+  /**
+   * Get the location of the node.
+   *
+   * @return An optional containing the location of the node if available.
+   */
+  @Override
+  public Optional<Bytes> getLocation() {
+    return Optional.of(location);
+  }
+
+  /**
+   * Get the value associated with the node.
+   *
+   * @return An optional containing the value of the node if available.
+   */
+  @Override
+  public Optional<V> getValue() {
+    final Node<V> node = load();
+    return node.getValue();
+  }
+
+  /**
+   * Get the hash associated with the node.
+   *
+   * @return An optional containing the hash of the node if available.
+   */
+  @Override
+  public Optional<Bytes32> getHash() {
+    final Node<V> node = load();
+    return node.getHash();
+  }
+
+  /**
+   * Replace the path of the node.
+   *
+   * @param path The new path to set.
+   * @return A new node with the updated path.
+   */
+  @Override
+  public Node<V> replacePath(Bytes path) {
+    final Node<V> node = load();
+    markDirty();
+    loadedNode = Optional.of(node.replacePath(path));
+    return loadedNode.get();
+  }
+
+  /**
+   * Get the encoded value of the node.
+   *
+   * @return The encoded value of the node.
+   */
+  @Override
+  public Bytes getEncodedValue() {
+    final Node<V> node = load();
+    return node.getEncodedValue();
+  }
+
+  /**
+   * Get the children nodes of this node.
+   *
+   * @return A list of children nodes.
+   */
+  @Override
+  public List<Node<V>> getChildren() {
+    final Node<V> node = load();
+    return node.getChildren();
+  }
+
+  /** Marks the node as needs to be persisted */
+  @Override
+  public void markDirty() {
+    dirty = true;
+  }
+
+  /**
+   * Is this node not persisted and needs to be?
+   *
+   * @return True if the node needs to be persisted.
+   */
+  @Override
+  public boolean isDirty() {
+    return dirty;
+  }
+
+  /**
+   * Get a string representation of the node.
+   *
+   * @return A string representation of the node.
+   */
+  @Override
+  public String print() {
+    final Node<V> node = load();
+    return node.print();
+  }
+
+  private Node<V> load() {
+    if (!loadedNode.isPresent()) {
+      loadedNode = nodeFactory.retrieve(location, null);
+    }
+    return loadedNode.orElse(NullNode.instance());
+  }
+}

--- a/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/StoredVerkleTrieTest.java
+++ b/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/StoredVerkleTrieTest.java
@@ -18,10 +18,7 @@ package org.hyperledger.besu.ethereum.trie.verkle;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.ethereum.trie.verkle.factory.StoredNodeFactory;
-import org.hyperledger.besu.ethereum.trie.verkle.node.Node;
-import org.hyperledger.besu.ethereum.trie.verkle.node.NullNode;
 
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 
@@ -33,12 +30,12 @@ public class StoredVerkleTrieTest {
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     StoredNodeFactory<Bytes32> nodeFactory =
         new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    SimpleVerkleTrie<Bytes32, Bytes32> trie = new SimpleVerkleTrie<Bytes32, Bytes32>();
+    StoredVerkleTrie<Bytes32, Bytes32> trie = new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
     trie.commit(nodeUpdater);
-    assertThat(nodeUpdater.storage).isEmpty();
-    Node<Bytes32> storedRoot =
-        nodeFactory.retrieve(Bytes.EMPTY, Bytes32.ZERO).orElse(NullNode.instance());
-    assertThat(storedRoot).isInstanceOf(NullNode.class);
+
+    StoredVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
+    assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
   }
 
   @Test
@@ -47,7 +44,7 @@ public class StoredVerkleTrieTest {
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     StoredNodeFactory<Bytes32> nodeFactory =
         new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    SimpleVerkleTrie<Bytes32, Bytes32> trie = new SimpleVerkleTrie<Bytes32, Bytes32>();
+    StoredVerkleTrie<Bytes32, Bytes32> trie = new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
     Bytes32 key =
         Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
     Bytes32 value =
@@ -55,9 +52,9 @@ public class StoredVerkleTrieTest {
     trie.put(key, value);
     trie.commit(nodeUpdater);
 
-    Node<Bytes32> storedRoot = nodeFactory.retrieve(Bytes.EMPTY, Bytes32.ZERO).get();
-    SimpleVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new SimpleVerkleTrie<Bytes32, Bytes32>(storedRoot);
+    StoredVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
+    assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key).orElse(null)).as("Retrieved value").isEqualTo(value);
   }
 
@@ -67,7 +64,7 @@ public class StoredVerkleTrieTest {
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     StoredNodeFactory<Bytes32> nodeFactory =
         new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    SimpleVerkleTrie<Bytes32, Bytes32> trie = new SimpleVerkleTrie<Bytes32, Bytes32>();
+    StoredVerkleTrie<Bytes32, Bytes32> trie = new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
     Bytes32 key1 =
         Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
     Bytes32 value1 =
@@ -80,9 +77,9 @@ public class StoredVerkleTrieTest {
     trie.put(key2, value2);
     trie.commit(nodeUpdater);
 
-    Node<Bytes32> storedRoot = nodeFactory.retrieve(Bytes.EMPTY, Bytes32.ZERO).get();
-    SimpleVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new SimpleVerkleTrie<Bytes32, Bytes32>(storedRoot);
+    StoredVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
+    assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
   }
@@ -93,7 +90,7 @@ public class StoredVerkleTrieTest {
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     StoredNodeFactory<Bytes32> nodeFactory =
         new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    SimpleVerkleTrie<Bytes32, Bytes32> trie = new SimpleVerkleTrie<Bytes32, Bytes32>();
+    StoredVerkleTrie<Bytes32, Bytes32> trie = new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
     Bytes32 key1 =
         Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
     Bytes32 value1 =
@@ -106,9 +103,9 @@ public class StoredVerkleTrieTest {
     trie.put(key2, value2);
     trie.commit(nodeUpdater);
 
-    Node<Bytes32> storedRoot = nodeFactory.retrieve(Bytes.EMPTY, Bytes32.ZERO).get();
-    SimpleVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new SimpleVerkleTrie<Bytes32, Bytes32>(storedRoot);
+    StoredVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
+    assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
   }
@@ -119,7 +116,7 @@ public class StoredVerkleTrieTest {
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     StoredNodeFactory<Bytes32> nodeFactory =
         new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    SimpleVerkleTrie<Bytes32, Bytes32> trie = new SimpleVerkleTrie<Bytes32, Bytes32>();
+    StoredVerkleTrie<Bytes32, Bytes32> trie = new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
     Bytes32 key1 =
         Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
     Bytes32 value1 =
@@ -132,9 +129,9 @@ public class StoredVerkleTrieTest {
     trie.put(key2, value2);
     trie.commit(nodeUpdater);
 
-    Node<Bytes32> storedRoot = nodeFactory.retrieve(Bytes.EMPTY, Bytes32.ZERO).get();
-    SimpleVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new SimpleVerkleTrie<Bytes32, Bytes32>(storedRoot);
+    StoredVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
+    assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
   }
@@ -145,7 +142,7 @@ public class StoredVerkleTrieTest {
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     StoredNodeFactory<Bytes32> nodeFactory =
         new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    SimpleVerkleTrie<Bytes32, Bytes32> trie = new SimpleVerkleTrie<Bytes32, Bytes32>();
+    StoredVerkleTrie<Bytes32, Bytes32> trie = new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
     Bytes32 key1 =
         Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
     Bytes32 value1 =
@@ -163,9 +160,9 @@ public class StoredVerkleTrieTest {
     trie.put(key3, value3);
     trie.commit(nodeUpdater);
 
-    Node<Bytes32> storedRoot = nodeFactory.retrieve(Bytes.EMPTY, Bytes32.ZERO).get();
-    SimpleVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new SimpleVerkleTrie<Bytes32, Bytes32>(storedRoot);
+    StoredVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
+    assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
     assertThat(storedTrie.get(key3).orElse(null)).isEqualTo(value3);
@@ -177,7 +174,7 @@ public class StoredVerkleTrieTest {
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     StoredNodeFactory<Bytes32> nodeFactory =
         new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    SimpleVerkleTrie<Bytes32, Bytes32> trie = new SimpleVerkleTrie<Bytes32, Bytes32>();
+    StoredVerkleTrie<Bytes32, Bytes32> trie = new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
     Bytes32 key1 =
         Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
     Bytes32 value1 =
@@ -195,9 +192,9 @@ public class StoredVerkleTrieTest {
     trie.put(key3, value3);
     trie.commit(nodeUpdater);
 
-    Node<Bytes32> storedRoot = nodeFactory.retrieve(Bytes.EMPTY, Bytes32.ZERO).get();
-    SimpleVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new SimpleVerkleTrie<Bytes32, Bytes32>(storedRoot);
+    StoredVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredVerkleTrie<Bytes32, Bytes32>(nodeFactory);
+    assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
     assertThat(storedTrie.get(key3).orElse(null)).isEqualTo(value3);


### PR DESCRIPTION
## PR description
This PR adds a new StoredVerkleTrie class representing a VerkleTrie where Nodes can be fetched from storage as needed while walking through the Trie.

Currently, there is a SimpleVerkleTrie which can be constructed in memory only, and there is a StoredNodeFactory which can retrieve a single node from storage. However, there was no mechanism to walk a VerkleTrie where nodes are stored in storage. StoredVerkleTrie fills this gap.