### PR TITLE
ENH: returning old leafNode on value update

### DIFF
--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/PutVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/PutVisitor.java
@@ -112,7 +112,7 @@ public class PutVisitor<V> implements PathNodeVisitor<V> {
     if (commonPath.compareTo(nodePath) == 0) {
       final LeafNode<V> newNode = new LeafNode<V>(leafNode.getLocation(), value, path);
       newNode.markDirty();
-      return newNode;
+      return leafNode;
     }
 
     return insertNewBranching(leafNode, commonPath, pathSuffix, nodeSuffix);


### PR DESCRIPTION
## PR description
This PR makes a small but useful modification to the putVisitor.
It is very useful for the trie-log to be able to do the following within a single tree-traversal:
on updating an existing value, retrieve also the old value.