### PR TITLE
REFACTOR: Addition of StemNodes to capture SuffixExtensions

### DIFF
--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/VerkleTrie.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/VerkleTrie.java
@@ -39,7 +39,7 @@ public interface VerkleTrie<K, V> {
    * @param key The key that corresponds to the value to be updated.
    * @param value The value to associate the key with.
    */
-  void put(K key, V value);
+  Optional<V> put(K key, V value);
 
   /**
    * Deletes the value mapped to the specified key, if such a value exists (Optional operation).

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/IPAHasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/IPAHasher.java
@@ -36,7 +36,11 @@ public class IPAHasher implements Hasher<Bytes32> {
    */
   @Override
   public Bytes32 commit(Bytes32[] inputs) {
-    Bytes input_serialized = Bytes.concatenate(inputs);
-    return Bytes32.wrap(LibIpaMultipoint.commit(input_serialized.toArray()));
+    Bytes32[] rev = new Bytes32[inputs.length];
+    for (int i = 0; i < inputs.length; ++i) {
+      rev[i] = (Bytes32) inputs[i].reverse();
+    }
+    Bytes input_serialized = Bytes.concatenate(rev);
+    return (Bytes32) Bytes32.wrap(LibIpaMultipoint.commit(input_serialized.toArray())).reverse();
   }
 }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/InternalNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/InternalNode.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Besu Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.trie.verkle.node;
+
+import org.hyperledger.besu.ethereum.trie.verkle.visitor.NodeVisitor;
+import org.hyperledger.besu.ethereum.trie.verkle.visitor.PathNodeVisitor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.rlp.RLP;
+import org.apache.tuweni.rlp.RLPWriter;
+
+public class InternalNode<V> extends BranchNode<V> {
+  private Optional<Bytes> encodedValue = Optional.empty(); // Encoded value
+
+  /**
+   * Constructs a new InternalNode with location, hash, path, and children.
+   *
+   * @param location The location in the tree.
+   * @param hash Node's vector commitment's hash.
+   * @param commitment Node's vector commitment.
+   * @param children The list of children nodes.
+   */
+  public InternalNode(
+      final Bytes location,
+      final Bytes32 hash,
+      final Bytes32 commitment,
+      final List<Node<V>> children) {
+    super(location, hash, commitment, children);
+  }
+
+  /**
+   * Constructs a new InternalNode with optional location, optional hash, optional commitment and
+   * children.
+   *
+   * @param location The optional location in the tree.
+   * @param hash The optional vector commitment of children's commitments.
+   * @param commitment Node's optional vector commitment.
+   * @param children The list of children nodes.
+   */
+  public InternalNode(
+      final Optional<Bytes> location,
+      final Optional<Bytes32> hash,
+      final Optional<Bytes32> commitment,
+      final List<Node<V>> children) {
+    super(location, hash, commitment, children);
+  }
+
+  /**
+   * Constructs a new InternalNode with optional location, path, and children.
+   *
+   * @param location The optional location in the tree.
+   * @param children The list of children nodes.
+   */
+  public InternalNode(final Optional<Bytes> location, final List<Node<V>> children) {
+    super(location, children);
+  }
+
+  /**
+   * Constructs a new InternalNode with optional location and path, initializing children to
+   * NullNodes.
+   *
+   * @param location The optional location in the tree.
+   */
+  public InternalNode(final Bytes location) {
+    super(location);
+  }
+
+  /**
+   * Accepts a visitor for path-based operations on the node.
+   *
+   * @param visitor The path node visitor.
+   * @param path The path associated with a node.
+   * @return The result of the visitor's operation.
+   */
+  @Override
+  public Node<V> accept(final PathNodeVisitor<V> visitor, final Bytes path) {
+    return visitor.visit(this, path);
+  }
+
+  /**
+   * Accepts a visitor for generic node operations.
+   *
+   * @param visitor The node visitor.
+   * @return The result of the visitor's operation.
+   */
+  @Override
+  public Node<V> accept(final NodeVisitor<V> visitor) {
+    return visitor.visit(this);
+  }
+
+  /**
+   * Replace the vector commitment with a new one.
+   *
+   * @param hash The new vector commitment to set.
+   * @return A new BranchNode with the updated vector commitment.
+   */
+  public Node<V> replaceHash(Bytes32 hash, Bytes32 commitment) {
+    return new InternalNode<V>(
+        getLocation(), Optional.of(hash), Optional.of(commitment), getChildren());
+  }
+
+  /**
+   * Get the RLP-encoded value of the node.
+   *
+   * @return The RLP-encoded value.
+   */
+  @Override
+  public Bytes getEncodedValue() {
+    if (encodedValue.isPresent()) {
+      return encodedValue.get();
+    }
+    List<Bytes> values = Arrays.asList((Bytes) getHash().get(), (Bytes) getCommitment().get());
+    Bytes result = RLP.encodeList(values, RLPWriter::writeValue);
+    this.encodedValue = Optional.of(result);
+    return result;
+  }
+
+  /**
+   * Generates a string representation of the branch node and its children.
+   *
+   * @return A string representing the branch node and its children.
+   */
+  @Override
+  public String print() {
+    final StringBuilder builder = new StringBuilder();
+    builder.append("Internal:");
+    for (int i = 0; i < maxChild(); i++) {
+      final Node<V> child = child((byte) i);
+      if (child == NullNode.instance()) {
+        final String label = "[" + Integer.toHexString(i) + "] ";
+        final String childRep = child.print().replaceAll("\n\t", "\n\t\t");
+        builder.append("\n\t").append(label).append(childRep);
+      }
+    }
+    return builder.toString();
+  }
+}

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/Node.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/Node.java
@@ -32,8 +32,10 @@ import org.apache.tuweni.bytes.Bytes32;
  */
 public interface Node<V> {
 
-  /** A constant representing an empty hash value. */
+  /** A constant representing a commitment to NullNodes */
   Bytes32 EMPTY_HASH = Bytes32.ZERO;
+
+  Bytes32 EMPTY_COMMITMENT = Bytes32.ZERO;
 
   /**
    * Accept a visitor to perform operations on the node based on a provided path.
@@ -53,16 +55,6 @@ public interface Node<V> {
   Node<V> accept(NodeVisitor<V> visitor);
 
   /**
-   * Get the path associated with the node.
-   *
-   * @return The path of the node.
-   */
-  default Bytes getPath() {
-    return Bytes.EMPTY;
-  }
-  ;
-
-  /**
    * Get the location of the node.
    *
    * @return An optional containing the location of the node if available.
@@ -79,7 +71,6 @@ public interface Node<V> {
   default Optional<V> getValue() {
     return Optional.empty();
   }
-  ;
 
   /**
    * Get the hash associated with the node.
@@ -89,15 +80,15 @@ public interface Node<V> {
   default Optional<Bytes32> getHash() {
     return Optional.empty();
   }
-  ;
 
   /**
-   * Replace the path of the node.
+   * Get the commitment associated with the node.
    *
-   * @param path The new path to set.
-   * @return A new node with the updated path.
+   * @return An optional containing the hash of the node if available.
    */
-  Node<V> replacePath(Bytes path);
+  default Optional<Bytes32> getCommitment() {
+    return Optional.empty();
+  }
 
   /**
    * Get the encoded value of the node.

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/NullLeafNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/NullLeafNode.java
@@ -30,15 +30,15 @@ import org.apache.tuweni.bytes.Bytes32;
  * structure. It implements the Node interface and represents a node that contains no information or
  * value.
  */
-public class NullNode<V> implements Node<V> {
+public class NullLeafNode<V> implements Node<V> {
   @SuppressWarnings("rawtypes")
-  private static final NullNode instance = new NullNode();
+  private static final NullLeafNode instance = new NullLeafNode();
 
   /**
    * Constructs a new `NullNode`. This constructor is protected to ensure that `NullNode` instances
    * are only created as singletons.
    */
-  protected NullNode() {}
+  protected NullLeafNode() {}
 
   /**
    * Gets the shared instance of the `NullNode`.
@@ -47,7 +47,7 @@ public class NullNode<V> implements Node<V> {
    * @return The shared `NullNode` instance.
    */
   @SuppressWarnings("unchecked")
-  public static <V> NullNode<V> instance() {
+  public static <V> NullLeafNode<V> instance() {
     return instance;
   }
 
@@ -101,7 +101,7 @@ public class NullNode<V> implements Node<V> {
    */
   @Override
   public String print() {
-    return "[NULL]";
+    return "[NULL-LEAF]";
   }
 
   /**

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StemNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StemNode.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright Besu Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.trie.verkle.node;
+
+import org.hyperledger.besu.ethereum.trie.verkle.visitor.NodeVisitor;
+import org.hyperledger.besu.ethereum.trie.verkle.visitor.PathNodeVisitor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.rlp.RLP;
+import org.apache.tuweni.rlp.RLPWriter;
+
+public class StemNode<V> extends BranchNode<V> {
+  private final Node<V> NULL_LEAF_NODE = NullLeafNode.instance();
+
+  private final Bytes stem;
+  private final Optional<Bytes32> leftHash;
+  private final Optional<Bytes32> leftCommitment;
+  private final Optional<Bytes32> rightHash;
+  private final Optional<Bytes32> rightCommitment;
+  private Optional<Bytes> encodedValue = Optional.empty();
+
+  /**
+   * Constructs a new StemNode with non-optional parameters.
+   *
+   * @param location The location in the tree.
+   * @param stem Node's stem.
+   * @param hash Node's vector commitment's hash.
+   * @param commitment Node's vector commitment.
+   * @param leftHash Hash of vector commitment to left values.
+   * @param leftCommitment Vector commitment to left values.
+   * @param rightHash Hash of vector commitment to right values.
+   * @param rightCommitment Vector commitment to right values.
+   * @param children The list of children nodes.
+   */
+  public StemNode(
+      final Bytes location,
+      final Bytes stem,
+      final Bytes32 hash,
+      final Bytes32 commitment,
+      final Bytes32 leftHash,
+      final Bytes32 leftCommitment,
+      final Bytes32 rightHash,
+      final Bytes32 rightCommitment,
+      final List<Node<V>> children) {
+    super(location, hash, commitment, children);
+    this.stem = extractStem(stem);
+    this.leftHash = Optional.of(leftHash);
+    this.leftCommitment = Optional.of(leftCommitment);
+    this.rightHash = Optional.of(rightHash);
+    this.rightCommitment = Optional.of(rightCommitment);
+  }
+
+  /**
+   * Constructs a new StemNode with optional parameters.
+   *
+   * @param location Optional location in the tree.
+   * @param stem Node's stem.
+   * @param hash Optional node's vector commitment's hash.
+   * @param commitment Optional node's vector commitment.
+   * @param leftHash Optional hash of vector commitment to left values.
+   * @param leftCommitment Optional vector commitment to left values.
+   * @param rightHash Optional hash of vector commitment to right values.
+   * @param rightCommitment Optional vector commitment to right values.
+   * @param children The list of children nodes.
+   */
+  public StemNode(
+      final Optional<Bytes> location,
+      final Bytes stem,
+      final Optional<Bytes32> hash,
+      final Optional<Bytes32> commitment,
+      final Optional<Bytes32> leftHash,
+      final Optional<Bytes32> leftCommitment,
+      final Optional<Bytes32> rightHash,
+      final Optional<Bytes32> rightCommitment,
+      final List<Node<V>> children) {
+    super(location, hash, commitment, children);
+    this.stem = extractStem(stem);
+    this.leftHash = leftHash;
+    this.leftCommitment = leftCommitment;
+    this.rightHash = rightHash;
+    this.rightCommitment = rightCommitment;
+  }
+
+  /**
+   * Constructs a new BranchNode with non-optional parameters.
+   *
+   * @param location The location in the tree.
+   * @param stem Node's stem.
+   */
+  public StemNode(final Bytes location, final Bytes stem) {
+    super(location);
+    for (int i = 0; i < maxChild(); i++) {
+      replaceChild((byte) i, NULL_LEAF_NODE);
+    }
+    this.stem = extractStem(stem);
+    this.leftHash = Optional.empty();
+    this.leftCommitment = Optional.empty();
+    this.rightHash = Optional.empty();
+    this.rightCommitment = Optional.empty();
+  }
+
+  /**
+   * Accepts a visitor for path-based operations on the node.
+   *
+   * @param visitor The path node visitor.
+   * @param path The path associated with a node.
+   * @return The result of the visitor's operation.
+   */
+  @Override
+  public Node<V> accept(final PathNodeVisitor<V> visitor, final Bytes path) {
+    return visitor.visit(this, path);
+  }
+
+  /**
+   * Accepts a visitor for generic node operations.
+   *
+   * @param visitor The node visitor.
+   * @return The result of the visitor's operation.
+   */
+  @Override
+  public Node<V> accept(final NodeVisitor<V> visitor) {
+    return visitor.visit(this);
+  }
+
+  /**
+   * Get the stem.
+   *
+   * @return the stem.
+   */
+  public Bytes getStem() {
+    return stem;
+  }
+
+  /**
+   * Get the leftHash.
+   *
+   * @return the leftHash.
+   */
+  public Optional<Bytes32> getLeftHash() {
+    return leftHash;
+  }
+
+  /**
+   * Get the stem.
+   *
+   * @return the stem.
+   */
+  public Optional<Bytes32> getLeftCommitment() {
+    return leftCommitment;
+  }
+
+  /**
+   * Get the rightHash.
+   *
+   * @return the rightHash.
+   */
+  public Optional<Bytes32> getRightHash() {
+    return rightHash;
+  }
+
+  /**
+   * Get the stem.
+   *
+   * @return the stem.
+   */
+  public Optional<Bytes32> getRightCommitment() {
+    return rightCommitment;
+  }
+
+  /**
+   * Creates a new node by replacing its location
+   *
+   * @param location The location in the tree.
+   */
+  public StemNode<V> replaceLocation(final Bytes location) {
+    return new StemNode<V>(
+        Optional.of(location),
+        stem,
+        getHash(),
+        getCommitment(),
+        leftHash,
+        leftCommitment,
+        rightHash,
+        rightCommitment,
+        getChildren());
+  }
+
+  /**
+   * Creates a new node by replacing all its commitments
+   *
+   * @param hash Node's vector commitment hash
+   * @param commitment Node's vector commitment
+   * @param leftHash Node's left vector commitment hash
+   * @param leftCommitment Node's left vector commitment
+   * @param rightHash Node's right vector commitment hash
+   * @param rightCommitment Node's right vector commitment
+   */
+  public StemNode<V> replaceHash(
+      final Bytes32 hash,
+      final Bytes32 commitment,
+      final Bytes32 leftHash,
+      final Bytes32 leftCommitment,
+      final Bytes32 rightHash,
+      final Bytes32 rightCommitment) {
+    return new StemNode<V>(
+        getLocation().get(),
+        stem,
+        hash,
+        commitment,
+        leftHash,
+        leftCommitment,
+        rightHash,
+        rightCommitment,
+        getChildren());
+  }
+
+  /**
+   * Get the RLP-encoded value of the node.
+   *
+   * @return The RLP-encoded value.
+   */
+  @Override
+  public Bytes getEncodedValue() {
+    if (encodedValue.isPresent()) {
+      return encodedValue.get();
+    }
+    List<Bytes> values =
+        Arrays.asList(
+            getStem(),
+            (Bytes) getHash().get(),
+            (Bytes) getCommitment().get(),
+            (Bytes) getLeftHash().get(),
+            (Bytes) getLeftCommitment().get(),
+            (Bytes) getRightHash().get(),
+            (Bytes) getRightCommitment().get());
+    Bytes result = RLP.encodeList(values, RLPWriter::writeValue);
+    this.encodedValue = Optional.of(result);
+    return result;
+  }
+
+  /**
+   * Generates a string representation of the stem node and its children.
+   *
+   * @return A string representing the stem node and its children.
+   */
+  @Override
+  public String print() {
+    final StringBuilder builder = new StringBuilder();
+    builder.append("Stem:");
+    for (int i = 0; i < maxChild(); i++) {
+      final Node<V> child = child((byte) i);
+      if (child == NullLeafNode.instance()) {
+        final String label = "[" + Integer.toHexString(i) + "] ";
+        final String childRep = child.print().replaceAll("\n\t", "\n\t\t");
+        builder.append("\n\t").append(label).append(childRep);
+      }
+    }
+    return builder.toString();
+  }
+
+  private Bytes extractStem(final Bytes stemValue) {
+    return stemValue.slice(0, 31);
+  }
+}

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StoredNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StoredNode.java
@@ -64,18 +64,6 @@ public class StoredNode<V> implements Node<V> {
   }
 
   /**
-   * Get the path associated with the node.
-   *
-   * @return The path of the node.
-   */
-  @Override
-  public Bytes getPath() {
-    final Node<V> node = load();
-    return node.getPath();
-  }
-  ;
-
-  /**
    * Get the location of the node.
    *
    * @return An optional containing the location of the node if available.
@@ -108,17 +96,14 @@ public class StoredNode<V> implements Node<V> {
   }
 
   /**
-   * Replace the path of the node.
+   * Get the commitment associated with the node.
    *
-   * @param path The new path to set.
-   * @return A new node with the updated path.
+   * @return An optional containing the commitment of the node if available.
    */
   @Override
-  public Node<V> replacePath(Bytes path) {
+  public Optional<Bytes32> getCommitment() {
     final Node<V> node = load();
-    markDirty();
-    loadedNode = Optional.of(node.replacePath(path));
-    return loadedNode.get();
+    return node.getCommitment();
   }
 
   /**

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/FlattenVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/FlattenVisitor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Besu Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.trie.verkle.visitor;
+
+import org.hyperledger.besu.ethereum.trie.verkle.node.InternalNode;
+import org.hyperledger.besu.ethereum.trie.verkle.node.Node;
+import org.hyperledger.besu.ethereum.trie.verkle.node.NullNode;
+import org.hyperledger.besu.ethereum.trie.verkle.node.StemNode;
+
+import org.apache.tuweni.bytes.Bytes;
+
+public class FlattenVisitor<V> implements PathNodeVisitor<V> {
+  private final Node<V> NULL_NODE = NullNode.instance();
+
+  @Override
+  public Node<V> visit(InternalNode<V> internalNode, Bytes path) {
+    return NULL_NODE;
+  }
+
+  @Override
+  public Node<V> visit(StemNode<V> stemNode, Bytes path) {
+    final Bytes location = stemNode.getLocation().get();
+    final Bytes newLocation = location.slice(0, location.size() - 1);
+    // Should not flatten root node
+    return (!newLocation.isEmpty() ? stemNode.replaceLocation(newLocation) : NULL_NODE);
+  }
+}

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/NodeVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/NodeVisitor.java
@@ -15,10 +15,12 @@
  */
 package org.hyperledger.besu.ethereum.trie.verkle.visitor;
 
-import org.hyperledger.besu.ethereum.trie.verkle.node.BranchNode;
+import org.hyperledger.besu.ethereum.trie.verkle.node.InternalNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.LeafNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.Node;
+import org.hyperledger.besu.ethereum.trie.verkle.node.NullLeafNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.NullNode;
+import org.hyperledger.besu.ethereum.trie.verkle.node.StemNode;
 
 /**
  * Defines a visitor interface for nodes in the Verkle Trie.
@@ -28,12 +30,24 @@ import org.hyperledger.besu.ethereum.trie.verkle.node.NullNode;
 public interface NodeVisitor<V> {
 
   /**
-   * Visits a branch node.
+   * Visits an internal node.
    *
-   * @param branchNode The branch node to visit.
+   * @param internalNode The internal node to visit.
+   * @return The result of visiting the internal node.
+   */
+  default Node<V> visit(InternalNode<V> internalNode) {
+    return internalNode;
+  }
+
+  /**
+   * Visits a stem node.
+   *
+   * @param stemNode The stem node to visit.
    * @return The result of visiting the branch node.
    */
-  Node<V> visit(BranchNode<V> branchNode);
+  default Node<V> visit(StemNode<V> stemNode) {
+    return stemNode;
+  }
 
   /**
    * Visits a leaf node.
@@ -41,7 +55,9 @@ public interface NodeVisitor<V> {
    * @param leafNode The leaf node to visit.
    * @return The result of visiting the leaf node.
    */
-  Node<V> visit(LeafNode<V> leafNode);
+  default Node<V> visit(LeafNode<V> leafNode) {
+    return leafNode;
+  }
 
   /**
    * Visits a null node.
@@ -49,5 +65,17 @@ public interface NodeVisitor<V> {
    * @param nullNode The null node to visit.
    * @return The result of visiting the null node.
    */
-  Node<V> visit(NullNode<V> nullNode);
+  default Node<V> visit(NullNode<V> nullNode) {
+    return nullNode;
+  }
+
+  /**
+   * Visits a null leaf node.
+   *
+   * @param nullLeafNode The null node to visit.
+   * @return The result of visiting the null node.
+   */
+  default Node<V> visit(NullLeafNode<V> nullLeafNode) {
+    return nullLeafNode;
+  }
 }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/PathNodeVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/PathNodeVisitor.java
@@ -15,10 +15,12 @@
  */
 package org.hyperledger.besu.ethereum.trie.verkle.visitor;
 
-import org.hyperledger.besu.ethereum.trie.verkle.node.BranchNode;
+import org.hyperledger.besu.ethereum.trie.verkle.node.InternalNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.LeafNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.Node;
+import org.hyperledger.besu.ethereum.trie.verkle.node.NullLeafNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.NullNode;
+import org.hyperledger.besu.ethereum.trie.verkle.node.StemNode;
 
 import org.apache.tuweni.bytes.Bytes;
 
@@ -31,13 +33,26 @@ import org.apache.tuweni.bytes.Bytes;
 public interface PathNodeVisitor<V> {
 
   /**
+   * Visits a internal node with a specified path.
+   *
+   * @param internalNode The internal node to visit.
+   * @param path The path associated with the visit.
+   * @return The result of visiting the internal node.
+   */
+  default Node<V> visit(InternalNode<V> internalNode, Bytes path) {
+    return internalNode;
+  }
+
+  /**
    * Visits a branch node with a specified path.
    *
-   * @param branchNode The branch node to visit.
+   * @param stemNode The branch node to visit.
    * @param path The path associated with the visit.
    * @return The result of visiting the branch node.
    */
-  Node<V> visit(BranchNode<V> branchNode, Bytes path);
+  default Node<V> visit(StemNode<V> stemNode, Bytes path) {
+    return stemNode;
+  }
 
   /**
    * Visits a leaf node with a specified path.
@@ -46,7 +61,9 @@ public interface PathNodeVisitor<V> {
    * @param path The path associated with the visit.
    * @return The result of visiting the leaf node.
    */
-  Node<V> visit(LeafNode<V> leafNode, Bytes path);
+  default Node<V> visit(LeafNode<V> leafNode, Bytes path) {
+    return leafNode;
+  }
 
   /**
    * Visits a null node with a specified path.
@@ -55,5 +72,18 @@ public interface PathNodeVisitor<V> {
    * @param path The path associated with the visit.
    * @return The result of visiting the null node.
    */
-  Node<V> visit(NullNode<V> nullNode, Bytes path);
+  default Node<V> visit(NullNode<V> nullNode, Bytes path) {
+    return nullNode;
+  }
+
+  /**
+   * Visits a null leaf node with a specified path.
+   *
+   * @param nullLeafNode The null leaf node to visit.
+   * @param path The path associated with the visit.
+   * @return The result of visiting the null node.
+   */
+  default Node<V> visit(NullLeafNode<V> nullLeafNode, Bytes path) {
+    return nullLeafNode;
+  }
 }

--- a/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/SimpleVerkleTrieTest.java
+++ b/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/SimpleVerkleTrieTest.java
@@ -17,14 +17,8 @@ package org.hyperledger.besu.ethereum.trie.verkle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.hyperledger.besu.ethereum.trie.verkle.node.BranchNode;
-import org.hyperledger.besu.ethereum.trie.verkle.node.LeafNode;
-import org.hyperledger.besu.ethereum.trie.verkle.node.Node;
-import org.hyperledger.besu.ethereum.trie.verkle.node.NullNode;
-
 import java.util.Optional;
 
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 
@@ -33,8 +27,6 @@ public class SimpleVerkleTrieTest {
   @Test
   public void testEmptyTrie() {
     SimpleVerkleTrie<Bytes32, Bytes32> trie = new SimpleVerkleTrie<Bytes32, Bytes32>();
-    Node<Bytes32> root = trie.getRoot();
-    assertThat(root).as("Empty Trie is a NullNode").isInstanceOf(NullNode.class);
     assertThat(trie.getRootHash()).as("Retrieve root hash").isEqualByComparingTo(Bytes32.ZERO);
   }
 
@@ -46,13 +38,11 @@ public class SimpleVerkleTrieTest {
     Bytes32 value =
         Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
     trie.put(key, value);
-    Node<Bytes32> root = trie.getRoot();
-    assertThat(root).as("One value trie's root is a LeafNode").isInstanceOf(LeafNode.class);
     assertThat(trie.get(key))
         .as("Get one value should be the inserted value")
         .isEqualTo(Optional.of(value));
     Bytes32 expectedRootHash =
-        Bytes32.fromHexString("0x0919cd252910ea715338943554cdf800fe9b951f47182f8d7ae5be9ce4f5ec65");
+        Bytes32.fromHexString("afceaacfd8f1d62ceff7d2bbfc733e42fdb40cef6f7c3c870a5bdd9203c30a16");
     assertThat(trie.getRootHash()).as("Retrieve root hash").isEqualByComparingTo(expectedRootHash);
   }
 
@@ -67,31 +57,17 @@ public class SimpleVerkleTrieTest {
         Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddee00");
     Bytes32 value2 =
         Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
-    Bytes path =
-        Bytes.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddee");
-    byte index1 = key1.get(31);
-    byte index2 = key2.get(31);
-    byte index3 = (byte) 2;
+    Bytes32 key3 =
+        Bytes32.fromHexString("0xde112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
     trie.put(key1, value1);
     trie.put(key2, value2);
-    Node<Bytes32> root = trie.getRoot();
-    assertThat(root).as("Many values trie is a BranchNode").isInstanceOf(BranchNode.class);
-    BranchNode<Bytes32> branchRoot = (BranchNode<Bytes32>) root;
-    assertThat(branchRoot.child(index1))
-        .as("Child at index of first key is a LeafNode")
-        .isInstanceOf(LeafNode.class);
-    assertThat(branchRoot.child(index2))
-        .as("Child at index of second key is a LeafNode")
-        .isInstanceOf(LeafNode.class);
-    assertThat(branchRoot.child(index3))
-        .as("Child at another index is a NullNode")
-        .isInstanceOf(NullNode.class);
-    assertThat(branchRoot.getPath()).as("Path is the common stem").isEqualTo(path);
-    assertThat(trie.get(key1)).as("Retrieve first value").isEqualTo(Optional.of(value1));
-    assertThat(trie.get(key2)).as("Retrieve second value").isEqualTo(Optional.of(value2));
+    assertThat(trie.get(key1).get()).as("Get first value").isEqualByComparingTo(value1);
+    assertThat(trie.get(key2).get()).as("Get second value").isEqualByComparingTo(value2);
+    assertThat(trie.get(key3)).as("Get non-key returns empty").isEmpty();
+
     Bytes32 expectedRootHash =
-        Bytes32.fromHexString("0x0664595728997574720abefebd044352ab20b353f5c8bdb5558d1f17d71d171c");
-    assertThat(trie.getRootHash()).as("Retrieve root hash").isEqualByComparingTo(expectedRootHash);
+        Bytes32.fromHexString("1defb89c793eb6cf89a90fe7e9bff4b96b5c9774ad21433adb959466a7669602");
+    assertThat(trie.getRootHash()).as("Get root hash").isEqualByComparingTo(expectedRootHash);
   }
 
   @Test
@@ -105,29 +81,12 @@ public class SimpleVerkleTrieTest {
         Bytes32.fromHexString("0xff112233445566778899aabbccddeeff00112233445566778899aabbccddee00");
     Bytes32 value2 =
         Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
-    Bytes path = Bytes.fromHexString("0x");
-    byte index1 = key1.get(0);
-    byte index2 = key2.get(0);
-    byte index3 = (byte) 2;
     trie.put(key1, value1);
     trie.put(key2, value2);
-    Node<Bytes32> root = trie.getRoot();
-    assertThat(root).as("Many values trie's root is a BranchNode").isInstanceOf(BranchNode.class);
-    BranchNode<Bytes32> branchRoot = (BranchNode<Bytes32>) root;
-    assertThat(branchRoot.child(index1))
-        .as("Child at index of first key is a LeafNode")
-        .isInstanceOf(LeafNode.class);
-    assertThat(branchRoot.child(index2))
-        .as("Child at index of second key is a LeafNode")
-        .isInstanceOf(LeafNode.class);
-    assertThat(branchRoot.child(index3))
-        .as("Child at another index is a NullNode")
-        .isInstanceOf(NullNode.class);
-    assertThat(branchRoot.getPath()).as("Path is the common stem").isEqualTo(path);
-    assertThat(trie.get(key1)).as("Retrieve first value").isEqualTo(Optional.of(value1));
-    assertThat(trie.get(key2)).as("Retrieve second value").isEqualTo(Optional.of(value2));
+    assertThat(trie.get(key1).get()).as("Get first value").isEqualByComparingTo(value1);
+    assertThat(trie.get(key2).get()).as("Get second value").isEqualByComparingTo(value2);
     Bytes32 expectedRootHash =
-        Bytes32.fromHexString("0x18344e51ea6f0699b227f8a00871547430aebba457d4f7d0830315e7b683bba1");
+        Bytes32.fromHexString("1758925a729ae085d4a2e32139f47c647f70495a6a38053bc0056996dd34b60e");
     assertThat(trie.getRootHash()).as("Retrieve root hash").isEqualByComparingTo(expectedRootHash);
   }
 
@@ -142,29 +101,12 @@ public class SimpleVerkleTrieTest {
         Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
     Bytes32 value2 =
         Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
-    Bytes path = Bytes.fromHexString("0x00");
-    byte index1 = key1.get(1);
-    byte index2 = key2.get(1);
-    byte index3 = (byte) 0;
     trie.put(key1, value1);
     trie.put(key2, value2);
-    Node<Bytes32> root = trie.getRoot();
-    assertThat(root).as("Many values trie's root is a BranchNode").isInstanceOf(BranchNode.class);
-    BranchNode<Bytes32> branchRoot = (BranchNode<Bytes32>) root;
-    assertThat(branchRoot.child(index1))
-        .as("Child at index of first key is a LeafNode")
-        .isInstanceOf(LeafNode.class);
-    assertThat(branchRoot.child(index2))
-        .as("Child at index of second key is a LeafNode")
-        .isInstanceOf(LeafNode.class);
-    assertThat(branchRoot.child(index3))
-        .as("Child at another index is a NullNode")
-        .isInstanceOf(NullNode.class);
-    assertThat(branchRoot.getPath()).as("Path is the common stem").isEqualTo(path);
     assertThat(trie.get(key1)).as("Retrieve first value").isEqualTo(Optional.of(value1));
     assertThat(trie.get(key2)).as("Retrieve second value").isEqualTo(Optional.of(value2));
     Bytes32 expectedRootHash =
-        Bytes32.fromHexString("0x0c0f178f291e1113c56903cfcfd7023e64550058127d8de4995461760262a7be");
+        Bytes32.fromHexString("88028cbafb20137dba8b42d243cfcac81f6ac635cf984c7a89e54ef006bf750d");
     assertThat(trie.getRootHash()).as("Retrieve root hash").isEqualByComparingTo(expectedRootHash);
   }
 
@@ -183,12 +125,8 @@ public class SimpleVerkleTrieTest {
     trie.put(key2, value2);
     trie.remove(key1);
     assertThat(trie.get(key1)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-    assertThat(trie.getRoot())
-        .as("One value => flatten to one LeafNode")
-        .isInstanceOf(LeafNode.class);
     trie.remove(key2);
     assertThat(trie.get(key2)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-    assertThat(trie.getRoot()).as("No value => back to NullNode root").isInstanceOf(NullNode.class);
   }
 
   @Test
@@ -206,12 +144,8 @@ public class SimpleVerkleTrieTest {
     trie.put(key2, value2);
     trie.remove(key1);
     assertThat(trie.get(key1)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-    assertThat(trie.getRoot())
-        .as("One value => flatten to one LeafNode")
-        .isInstanceOf(LeafNode.class);
     trie.remove(key2);
     assertThat(trie.get(key2)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-    assertThat(trie.getRoot()).as("No value => back to NullNode root").isInstanceOf(NullNode.class);
   }
 
   @Test
@@ -229,12 +163,8 @@ public class SimpleVerkleTrieTest {
     trie.put(key2, value2);
     trie.remove(key1);
     assertThat(trie.get(key1)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-    assertThat(trie.getRoot())
-        .as("One value => flatten to one LeafNode")
-        .isInstanceOf(LeafNode.class);
     trie.remove(key2);
     assertThat(trie.get(key2)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-    assertThat(trie.getRoot()).as("No value => back to NullNode root").isInstanceOf(NullNode.class);
   }
 
   @Test
@@ -283,24 +213,11 @@ public class SimpleVerkleTrieTest {
     trie.put(key1, value1);
     trie.put(key2, value2);
     trie.put(key3, value3);
-    assertThat(trie.getRoot().getPath())
-        .as("Initial extension path")
-        .isEqualTo(Bytes.fromHexString("0x00"));
     trie.remove(key1);
     assertThat(trie.get(key1)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-    assertThat(trie.getRoot().getPath())
-        .as("First flatten: extension path")
-        .isEqualTo(
-            Bytes.fromHexString(
-                "0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccdd"));
     assertThat(trie.get(key2)).as("Retrieve second value").isEqualTo(Optional.of(value2));
     trie.remove(key2);
     assertThat(trie.get(key2)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-    assertThat(trie.getRoot().getPath())
-        .as("Second flatten: extension path")
-        .isEqualTo(
-            Bytes.fromHexString(
-                "0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddff"));
     assertThat(trie.get(key3)).as("Retrieve first value").isEqualTo(Optional.of(value3));
     trie.remove(key3);
     assertThat(trie.get(key3)).as("Make sure value is deleted").isEqualTo(Optional.empty());


### PR DESCRIPTION
## PR description
This is a major refactoring that solves several problems:

  - Ready to generate proof data: StemNodes capture the suffix-extensions from the specs, with its intermediate commitments.
  - Root hashes can be tested against testnet: they are coherent with go-verkle and rust-verkle.
  - Trie can be stored/retrieved from database: StoredVerkleTrie makes it transparent to work with a Trie that is not completely loaded in memory and looks for nodes in the database when needed.
  - Put key-value returns the old value : this is helpful for rollbacks and trie-logs.




## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->