### PR TITLE
fix main storage offset

### DIFF
--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/adapter/TrieKeyAdapter.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/adapter/TrieKeyAdapter.java
@@ -39,7 +39,12 @@ public class TrieKeyAdapter {
   private final UInt256 HEADER_STORAGE_OFFSET = UInt256.valueOf(64);
   private final UInt256 CODE_OFFSET = UInt256.valueOf(128);
   private final UInt256 VERKLE_NODE_WIDTH = UInt256.valueOf(256);
-  private final UInt256 MAIN_STORAGE_OFFSET = UInt256.valueOf(256).pow(31);
+
+  // TODO should be UInt256.valueOf(256).pow(31) , but there is currently a bug
+  // in the testnet and instead, the other clients are using a shift left operation.
+  // So we are doing a shift left to follow the testnet,
+  // but this should be fixed later.
+  private final UInt256 MAIN_STORAGE_OFFSET = UInt256.valueOf(256).shiftLeft(31);
 
   private final Hasher hasher;
 

--- a/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/TrieKeyAdapterTest.java
+++ b/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/TrieKeyAdapterTest.java
@@ -48,6 +48,15 @@ public class TrieKeyAdapterTest {
   }
 
   @Test
+  public void testStorageKeyForMainStorage() {
+    UInt256 storageKey = UInt256.valueOf(64);
+    // use shift left operation for the moment , should be pow in the future
+    Bytes32 expected =
+        Bytes32.fromHexString("0x3d08fd033c8f1e8b95f28b95a854a0e948062cb7ecb87587e54dcd826e577640");
+    assertThat(adapter.storageKey(address, storageKey)).isEqualTo(expected);
+  }
+
+  @Test
   public void testCodeChunkKey() {
     UInt256 chunkId = UInt256.valueOf(24);
     // Need to change this once commit is fixed


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->

## PR description

should be UInt256.valueOf(256).pow(31) , but there is currently a bug in the testnet and instead, the other clients are using a shift left operation. So we are doing a shift left to follow the testnet, but this should be fixed later.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->