### PR TITLE
fix invalid state root hash

### DIFF
--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/Hasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/Hasher.java
@@ -29,6 +29,7 @@ public interface Hasher {
    */
   public Bytes32 commit(Bytes32[] inputs);
 
+  public Bytes32 commitRoot(Bytes32[] inputs);
   /**
    * Calculates the hash for an address and index.
    *

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
@@ -45,6 +45,16 @@ public class PedersenHasher implements Hasher {
     return (Bytes32) Bytes32.wrap(LibIpaMultipoint.commit(input_serialized.toArray())).reverse();
   }
 
+  @Override
+  public Bytes32 commitRoot(final Bytes32[] inputs) {
+    Bytes32[] rev = new Bytes32[inputs.length];
+    for (int i = 0; i < inputs.length; ++i) {
+      rev[i] = (Bytes32) inputs[i].reverse();
+    }
+    Bytes input_serialized = Bytes.concatenate(rev);
+    return Bytes32.wrap(LibIpaMultipoint.commitRoot(input_serialized.toArray()));
+  }
+
   /**
    * Calculates the hash for an address and index.
    *

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/SHA256Hasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/SHA256Hasher.java
@@ -49,6 +49,11 @@ public class SHA256Hasher implements Hasher {
     return out;
   }
 
+  @Override
+  public Bytes32 commitRoot(final Bytes32[] inputs) {
+    return commit(inputs);
+  }
+
   /**
    * Calculates the hash for an address and index.
    *

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/HashVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/HashVisitor.java
@@ -59,7 +59,12 @@ public class HashVisitor<V extends Bytes> implements PathNodeVisitor<V> {
       internalNode.replaceChild(index, updatedChild);
       hashes[i] = updatedChild.getHash().get();
     }
-    final Bytes32 hash = hasher.commit(hashes);
+    final Bytes32 hash;
+    if (location.isEmpty()) {
+      hash = hasher.commitRoot(hashes);
+    } else {
+      hash = hasher.commit(hashes);
+    }
     return internalNode.replaceHash(hash, hash); // commitment should be different
   }
 

--- a/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/SimpleVerkleTrieTest.java
+++ b/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/SimpleVerkleTrieTest.java
@@ -43,7 +43,7 @@ public class SimpleVerkleTrieTest {
         .as("Get one value should be the inserted value")
         .isEqualTo(Optional.of(value));
     Bytes32 expectedRootHash =
-        Bytes32.fromHexString("afceaacfd8f1d62ceff7d2bbfc733e42fdb40cef6f7c3c870a5bdd9203c30a16");
+        Bytes32.fromHexString("0x70985156c77f266a97c35d5a051b6c48b3ed64669105ea0a6a248220bedaece4");
     assertThat(trie.getRootHash()).as("Retrieve root hash").isEqualByComparingTo(expectedRootHash);
   }
 
@@ -67,7 +67,7 @@ public class SimpleVerkleTrieTest {
     assertThat(trie.get(key3)).as("Get non-key returns empty").isEmpty();
 
     Bytes32 expectedRootHash =
-        Bytes32.fromHexString("1defb89c793eb6cf89a90fe7e9bff4b96b5c9774ad21433adb959466a7669602");
+        Bytes32.fromHexString("0x0e6714b82adb7af3d814aac5386878295949ded4eae3e33e08844af49fe042ba");
     assertThat(trie.getRootHash()).as("Get root hash").isEqualByComparingTo(expectedRootHash);
   }
 
@@ -87,7 +87,7 @@ public class SimpleVerkleTrieTest {
     assertThat(trie.get(key1).get()).as("Get first value").isEqualByComparingTo(value1);
     assertThat(trie.get(key2).get()).as("Get second value").isEqualByComparingTo(value2);
     Bytes32 expectedRootHash =
-        Bytes32.fromHexString("1758925a729ae085d4a2e32139f47c647f70495a6a38053bc0056996dd34b60e");
+        Bytes32.fromHexString("0x60d94a57c00df92c007416aac3d85cac54cd979408b0865088fc296611c65efc");
     assertThat(trie.getRootHash()).as("Retrieve root hash").isEqualByComparingTo(expectedRootHash);
   }
 
@@ -107,7 +107,7 @@ public class SimpleVerkleTrieTest {
     assertThat(trie.get(key1)).as("Retrieve first value").isEqualTo(Optional.of(value1));
     assertThat(trie.get(key2)).as("Retrieve second value").isEqualTo(Optional.of(value2));
     Bytes32 expectedRootHash =
-        Bytes32.fromHexString("88028cbafb20137dba8b42d243cfcac81f6ac635cf984c7a89e54ef006bf750d");
+        Bytes32.fromHexString("0x4fd3848fecececd160dad21e25eef54c40e39813814968f63971c0cb458e95ab");
     assertThat(trie.getRootHash()).as("Retrieve root hash").isEqualByComparingTo(expectedRootHash);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->

## PR description

Fix the state root hash that was invalid with Verkle. We have two methods in the IPA multipoint library. One is called commitRoot and the other is called commit. We need to call the first one only for the root node in order to have a serialize compressed value for the stateroot.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->