### PR TITLE
fix leaf deletion issue

### DIFF
--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/InternalNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/InternalNode.java
@@ -150,10 +150,12 @@ public class InternalNode<V> extends BranchNode<V> {
     builder.append("Internal:");
     for (int i = 0; i < maxChild(); i++) {
       final Node<V> childNode = child((byte) i);
-      if (childNode != NullNode.instance() && !childNode.getEncodedValue().isEmpty()) {
-        final String label = String.format("[%02x] ", i);
-        final String childRep = childNode.print().replaceAll("\n\t", "\n\t\t");
-        builder.append("\n\t").append(label).append(childRep);
+      if (childNode != NullNode.instance()) {
+        if (!(childNode instanceof StoredNode) || !childNode.getEncodedValue().isEmpty()) {
+          final String label = String.format("[%02x] ", i);
+          final String childRep = childNode.print().replaceAll("\n\t", "\n\t\t");
+          builder.append("\n\t").append(label).append(childRep);
+        }
       }
     }
     return builder.toString();

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/InternalNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/InternalNode.java
@@ -150,7 +150,7 @@ public class InternalNode<V> extends BranchNode<V> {
     builder.append("Internal:");
     for (int i = 0; i < maxChild(); i++) {
       final Node<V> childNode = child((byte) i);
-      if (childNode != NullNode.instance()) {
+      if (childNode != NullNode.instance() && !childNode.getEncodedValue().isEmpty()) {
         final String label = String.format("[%02x] ", i);
         final String childRep = childNode.print().replaceAll("\n\t", "\n\t\t");
         builder.append("\n\t").append(label).append(childRep);

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/RemoveVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/RemoveVisitor.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.trie.verkle.node.Node;
 import org.hyperledger.besu.ethereum.trie.verkle.node.NullLeafNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.NullNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.StemNode;
+import org.hyperledger.besu.ethereum.trie.verkle.node.StoredNode;
 
 import java.util.List;
 import java.util.Optional;
@@ -142,11 +143,14 @@ public class RemoveVisitor<V> implements PathNodeVisitor<V> {
     final List<Node<V>> children = branchNode.getChildren();
     Optional<Byte> onlyChildIndex = Optional.empty();
     for (int i = 0; i < children.size(); ++i) {
-      if (children.get(i) != NULL_NODE && !children.get(i).getEncodedValue().isEmpty()) {
-        if (onlyChildIndex.isPresent()) {
-          return Optional.empty();
+      if (children.get(i) != NULL_NODE) {
+        if (!(children.get(i) instanceof StoredNode)
+            || !children.get(i).getEncodedValue().isEmpty()) {
+          if (onlyChildIndex.isPresent()) {
+            return Optional.empty();
+          }
+          onlyChildIndex = Optional.of((byte) i);
         }
-        onlyChildIndex = Optional.of((byte) i);
       }
     }
     return onlyChildIndex;

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/RemoveVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/RemoveVisitor.java
@@ -142,7 +142,7 @@ public class RemoveVisitor<V> implements PathNodeVisitor<V> {
     final List<Node<V>> children = branchNode.getChildren();
     Optional<Byte> onlyChildIndex = Optional.empty();
     for (int i = 0; i < children.size(); ++i) {
-      if (children.get(i) != NULL_NODE) {
+      if (children.get(i) != NULL_NODE && !children.get(i).getEncodedValue().isEmpty()) {
         if (onlyChildIndex.isPresent()) {
           return Optional.empty();
         }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->

## PR description

This PR fixes a bug that occurs when removing a key from a trie that isn't loaded. In a certain configuration, when we want to check if an internal node has only one child, we verify how many children are not NullNodes. However, when the node is not loaded, they are not NullNodes but StoredNodes. So, in the current code, we need to load the StoredNodes to see if they are null or not.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->