### PR TITLE
chore: update readme to mention calling gradlew instead of gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ To build the project, use the `build` task:
 
 
 ```bash
-gradle build
+./gradlew build
 ```
 
 To format the code according to the project's style guide, use the spotlessApply task:
 
 ```bash
-gradle spotlessApply
+./gradlew spotlessApply
 ```
 
 ## Contribute


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->

## PR description

When I ran `gradle` I was coming across errors due to my gradle version being 8.0. This changes the readme to specify calling ./graldew instead which will call the correct version for the project.

Found out after speaking with @matkt and @thomas-quadratic  

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->