### PR TITLE
chore: remove usage of `pedersenHash` in `trieKeyHash`

### DIFF
--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
@@ -68,8 +68,46 @@ public class PedersenHasher implements Hasher {
    */
   @Override
   public Bytes32 trieKeyHash(Bytes address, Bytes32 index) {
+
+    // Reverse the index so that it is in little endian format
+    Bytes32 indexLE = Bytes32.wrap(index.reverse());
+
+    // Pad the address so that it is 32 bytes
     Bytes32 addr = Bytes32.leftPad(address);
-    Bytes input = Bytes.concatenate(addr, index);
-    return Bytes32.wrap(LibIpaMultipoint.pedersenHash(input.toArray()));
+    Bytes input = Bytes.concatenate(addr, indexLE);
+
+    // The amount of bytes that we will take from the input
+    final int CHUNK_SIZE = 16;
+
+    // The input will always be 64 bytes and since we are taking 16 bytes at a time
+    // we will create four chunks from the input.
+    // An extra chunk which has a constant value is added as a domain separator and length encoder,
+    // making the total number of chunks equal to five.
+    final int NUM_CHUNKS = 5;
+
+    Bytes32[] chunks = new Bytes32[NUM_CHUNKS];
+
+    // Set the first chunk which is always 2 + 256 * 64
+    byte[] firstChunkBytes =
+        new byte[] {
+          2, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0
+        };
+    chunks[0] = Bytes32.wrap(firstChunkBytes);
+
+    // Given input is 64 bytes, we create exactly 4 chunks of 16 bytes each
+    // The chunks are then padded to 32 bytes since the commit methods requires 32 byte scalars.
+    for (int i = 0; i < NUM_CHUNKS - 1; i++) {
+      // Slice input into 16 byte segments
+      Bytes chunk = input.slice(i * CHUNK_SIZE, CHUNK_SIZE);
+      // Pad each chunk to make it 32 bytes
+      chunks[i + 1] = Bytes32.rightPad(chunk);
+    }
+
+    Bytes hashBE = Bytes.wrap(LibIpaMultipoint.commitRoot(Bytes.concatenate(chunks).toArray()));
+
+    // commitRoot returns the hash in big endian format, so we reverse it to get it in little endian
+    // format. When we migrate to using `groupToField`, this reverse will not be needed.
+    return Bytes32.wrap(hashBE.reverse());
   }
 }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
@@ -33,7 +33,7 @@ public class PedersenHasher implements Hasher {
   // called.
   private static final int CHUNK_SIZE = 16;
 
-  // The input will always be 64 bytes and since we are taking 16 bytes at a time
+  // The input will always be 64 bytes once it is padded in  `trieKeyHash ` and since we are taking 16 bytes at a time
   // we will create four chunks from the input.
   // An extra chunk which has a constant value is added as a domain separator and
   // length encoder,

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
@@ -83,21 +83,16 @@ public class PedersenHasher implements Hasher {
   public Bytes32 trieKeyHash(Bytes address, Bytes32 index) {
 
     // Reverse the index so that it is in little endian format
-    Bytes32 indexLE = Bytes32.wrap(index.reverse());
+    final Bytes32 indexLE = Bytes32.wrap(index.reverse());
 
     // Pad the address so that it is 32 bytes
-    Bytes32 addr = Bytes32.leftPad(address);
-    Bytes input = Bytes.concatenate(addr, indexLE);
+    final Bytes32 addr = Bytes32.leftPad(address);
+    final Bytes input = Bytes.concatenate(addr, indexLE);
 
-    Bytes32[] chunks = new Bytes32[NUM_CHUNKS];
+    final Bytes32[] chunks = new Bytes32[NUM_CHUNKS];
 
     // Set the first chunk which is always 2 + 256 * 64
-    final byte[] firstChunkBytes =
-        new byte[] {
-          2, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          0, 0
-        };
-    chunks[0] = Bytes32.wrap(firstChunkBytes);
+    chunks[0] = Bytes32.rightPad(Bytes.of(2, 64));
 
     // Given input is 64 bytes, we create exactly 4 chunks of 16 bytes each
     // The chunks are then padded to 32 bytes since the commit methods requires 32

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
@@ -29,15 +29,16 @@ import org.apache.tuweni.bytes.Bytes32;
  */
 public class PedersenHasher implements Hasher {
 
-  // The amount of bytes that we will take from the input when `trieKeyHash` is called.
-  final int CHUNK_SIZE = 16;
+  // The amount of bytes that we will take from the input when `trieKeyHash` is
+  // called.
+  private static final int CHUNK_SIZE = 16;
 
   // The input will always be 64 bytes and since we are taking 16 bytes at a time
   // we will create four chunks from the input.
   // An extra chunk which has a constant value is added as a domain separator and
   // length encoder,
   // making the total number of chunks equal to five.
-  final int NUM_CHUNKS = 5;
+  private static final int NUM_CHUNKS = 5;
 
   /**
    * Commits an array of Bytes32 using the pedersen commitment - multi scalar multiplication vector
@@ -98,7 +99,8 @@ public class PedersenHasher implements Hasher {
     chunks[0] = Bytes32.wrap(firstChunkBytes);
 
     // Given input is 64 bytes, we create exactly 4 chunks of 16 bytes each
-    // The chunks are then padded to 32 bytes since the commit methods requires 32 byte scalars.
+    // The chunks are then padded to 32 bytes since the commit methods requires 32
+    // byte scalars.
     for (int i = 0; i < NUM_CHUNKS - 1; i++) {
       // Slice input into 16 byte segments
       Bytes chunk = input.slice(i * CHUNK_SIZE, CHUNK_SIZE);
@@ -109,8 +111,10 @@ public class PedersenHasher implements Hasher {
     final Bytes hashBE =
         Bytes.wrap(LibIpaMultipoint.commitRoot(Bytes.concatenate(chunks).toArray()));
 
-    // commitRoot returns the hash in big endian format, so we reverse it to get it in little endian
-    // format. When we migrate to using `groupToField`, this reverse will not be needed.
+    // commitRoot returns the hash in big endian format, so we reverse it to get it
+    // in little endian
+    // format. When we migrate to using `groupToField`, this reverse will not be
+    // needed.
     return Bytes32.wrap(hashBE.reverse());
   }
 }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
@@ -33,8 +33,9 @@ public class PedersenHasher implements Hasher {
   // called.
   private static final int CHUNK_SIZE = 16;
 
-  // The input will always be 64 bytes once it is padded in  `trieKeyHash ` and since we are taking 16 bytes at a time
-  // we will create four chunks from the input.
+  // The input will always be 64 bytes once it is padded in `trieKeyHash `
+  // and since we are taking 16 bytes at a time we will create four chunks from
+  // the input.
   // An extra chunk which has a constant value is added as a domain separator and
   // length encoder,
   // making the total number of chunks equal to five.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->

## PR description

This removes the need for the multipoint library to expose `pedersenHash`. 

Ideally we would also decompose `commitRoot`, however this can be done in another PR.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->