### PR TITLE
Update commitments

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,193 @@
+# Besu's Verkle Trie Native Interfaces
+
+Besu's Verkle Trie implements Ethereum's world state, a key-value mapping with keys and values any 32-bytes string.
+To insure integrity, blocks include a commitment to the world-state that can be verified.
+Verkle Tries is a data structure implementing commitments for large key-value mappings leveraging an underlying small vector commitment scheme.
+
+Besu's Verkle Trie relies on a rust native library for its cryptographic vector commitment.
+The native library is from Besu's perspective responsible for vector commitment primitives, but not Verkle Trie's logic.
+
+This specification lay out a simple modular design with interfaces for communications between the modules.
+
+
+## Modules
+![native-interfaces](assets/native-interfaces.png)
+
+Firstly, we have at the ends of the figure the main functionality providers:
+
+- Besu: the main application, a Java library. Responsible for the verkle logic. It works with objects like nodes, addresses, ethereum types.
+- Crypto-crate: the main native application, a rust library. It provides cryptographic commitments and related operations. We currently use [rust-verkle](https://github.com/crate-crypto/rust-verkle).
+
+In order to communicate between the two applications, we use JNI. It maps rust functions from/to Java methods, providing entrypoints on both sides: 
+
+- JNI java-side: java class with native methods performing rust function invocation.
+- JNI rust-side: rust library exporting functions that take the JNI environment as input to communicate with the JVM.
+
+As the JNI uses lower-level objects such as raw bytes, we include interfaces whose purpose is to manage the passage to and from domain-specific objects.
+
+- Interfaces: java interfaces such as TrieKeyAdaptor and Hasher that encapsulates our application layer usecases.
+- FFI: rust traits and structures encapsulating its cryptographic layer.
+
+Interposing interfaces between the application layers and the JNI isolates the JNI from applications' details such as elliptic curve elements and ethereum types.
+
+## Cryptographic Functionalities
+The native library's purpose is to provide vector commitments primitives underlying Verkle's construction.
+Here are the functionalities that it should provide to Besu:
+
+- Commit to a dense/sparse vector of values (aka scalars).
+- Commit an update of a committed vector.
+- Convert commitment to value (for rolling-up the trie).
+- Generate proofs of openings.
+- Verify proofs.
+
+### Vector Commitments
+We recall what vector commitments do:
+
+- We publish a commitment C to a vector V (in reality, a polynomial).
+- The commitment is binding: we cannot (easily) find another vector W producing the same commitment C.
+- The commitment is succinct: its size is smaller than the vector itself.
+- The commitment is hiding (not important for us): we gain no knowledge of the vector from the commitment.
+- We later produce openings V[i] = v, that is a proof P that the ith value of V is v.
+- The proof is succinct.
+- The proof reveals i and v only, not the rest of the vector (not important for us).
+- Given C and P, anyone can verify that V[i] = v.
+- Finally, we can create a single succinct proof for many openings at once.
+
+Vector commitments primitives are provided by the native library rust-verkle.
+
+### Verkle Trie
+Vector commitments are in practice restricted in size.
+Verkle Tries roll-up a much larger vector commitment from a smaller vector commitment primitive.
+It recursively computes commitments over previously computed commitments or values until reaching a single root commitment using a bottom-up approach.
+It can be thought as Merkle Tries with vector commitments replacing hashes.
+
+Verkle Tries primitives are provided by besu-verkle-tries.
+
+## Communication
+For simplicity, the interfaces (Interfaces, JNI and FFI) follow these rules:
+
+- Data is passed between interfaces as little-endian bytes, always.
+- Data is encoded with RLP-encoding, always.
+- Interfaces main purpose is to prepare I/O and delegate to an appropriate module, minimizing coupling.
+- Types are checked in the interfaces before the JNI. All operations in JNI can be assumed typed safe. This avoids error propagation between different processes.
+
+### Types
+We propose in this section types reflecting the different objects that are used in the interfaces. These types are always little endian bytes.
+
+#### Commitments
+Commitments are theoretically banderwagon elements coming from elliptic curve points.
+There are two ways to serialise/deserialise a commitment reflected by the following types:
+
+- CommitmentBytes: 64-le-bytes representing an uncompressed commitment.
+- CommitmentBytesCompressed: 32-le-bytes representing a compressed commitment.
+
+The difference between uncompressed and compressed serialisation is a matter of trade-off between memory and computation.
+Compressed commitments are half the size, but deserialisation is more costly. The interface include conversions between the two.
+
+#### Scalar Field Elements
+Values that can be committed to are theoretically elements from the banderwagon scalar field, a prime field.
+
+- ScalarBytes: 32-le-bytes representing a value (a scalar).
+
+Note that commitments themselves need to be recursively committed to in Verkle Tries.
+There is a map from commitments to scalars, but one cannot always retrieve uniquely a commitment from its scalar.
+
+### Conversions
+
+
+#### Commitments
+
+```rust
+// Decodes a CommitmentBytes from bytes, else throws an Error.
+pub fn commitment_from(bytes: &[u8]) -> Result<CommitmentBytes, Error>;
+
+// Tries to create a vector of CommitmentBytes from bytes, else throws an Error.
+pub fn try_commitment_vec_from(bytes: &[u8]) -> Result<Vec<CommitmentBytes>, Error>;
+```
+
+#### Scalar Field Elements
+
+```rust
+// Tries to create a ScalarBytes from bytes, else throws an Error.
+pub fn try_scalar_from(bytes: &[u8]) -> Result<ScalarBytes, Error>;
+
+// Tries to create a vector of ScalarBytes from bytes, else throws an Error.
+pub fn try_scalar_vec_from(bytes: &[u8]) -> Result<Vec<ScalarBytes>, Error>;
+```
+
+#### Safe Conversions
+```rust
+pub fn compress_commitment(commitment: CommitmentBytes) -> CommitmentBytesCompressed;
+
+pub fn to_scalar(commitment: CommitmentBytes) -> ScalarBytes;
+
+// Optimised vector version
+pub fn to_scalar_vec(commitments: Vec<CommitmentBytes>) -> Vec<ScalarBytes>;
+```
+
+## Functionalities
+
+### Rust
+#### Committing
+
+```rust
+pub trait commit {
+    // Commit to a dense vector of values
+    pub fn commit(&self, values: Vec<ScalarBytes>) -> CommitmentBytes;
+    // Commit to a sparse vector of values
+    pub fn commit_sparse(&self, values: HashMap<u8, ScalarBytes>) -> CommitmentBytes;
+}
+```
+
+#### Updates
+For representing updates, we will need to keep track of the old and new values, which are recorded in the following type:
+
+```rust
+pub struct ScalarBytesDelta {
+    pub old: ScalarBytes,
+    pub new: ScalarBytes,
+}
+
+pub trait commit_update {
+    // Commit an update of a single value
+    pub fn commit_update(&self, commitment: CommitmentBytes, delta: ScalarBytesDelta, index: u8) -> CommitmentBytes;
+    // Commit an update of a sparse vector of values
+    pub fn commit_update_sparse(&self, commitment: CommitmentBytes, deltas: HashMap<u8, ScalarBytesDelta>) -> CommitmentBytes;
+}
+```
+
+### JNI
+Verkle Trie makes use of commitments for several different usecases: trie keys, committing values, committing child commitments, committing stem data and state root.
+
+All the usecases could be covered by 32-bytes values, but for optimisation purposes, we allow values of possibly smaller fixed-size bytes, given as a parameter.
+
+```Java
+public static native byte[] commit(byte byte_size, byte[] input);
+```
+
+```rust
+#[no_mangle]
+pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_commit(
+    env: JNIEnv, _class: JClass<'_>, byte_size: u8, values: jbyteArray
+) -> jbyteArray; 
+```
+
+### Java-Interfaces
+Interfaces on Java-side allow Besu to work at a higher-level, not knowing JNI's formats of communication between Java and rust.
+
+```Java
+// TODO: update this section.
+
+// Compressed commitment of 5 16-le-bytes values.
+// This will change to use mapCommitmentToScalar.
+public Bytes32 trieKey(address: Bytes, index: Bytes32);
+
+// Convert to 17-le-bytes values for commitment.
+public byte[] updateLeafValues();
+
+// Convert to 32-le-bytes values for commitment.
+public byte[] updateInternalValues();
+
+// Receives a commitment, both uncompressed and compressed.
+public Bytes32[3] commitment(input: byte[96]);
+```

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/Hasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/Hasher.java
@@ -15,35 +15,81 @@
  */
 package org.hyperledger.besu.ethereum.trie.verkle.hasher;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 /** Defines an interface for a Verkle Trie node hashing strategy. */
 public interface Hasher {
+  public Bytes getDefaultCommitment();
+
+  public Bytes32 getDefaultScalar();
 
   /**
-   * Calculates the commitment hash for an array of inputs.
+   * Compute commitment to a dense vector of scalar values.
    *
-   * @param inputs An array of values to be hashed.
+   * @param scalars Serialised scalar values to commit to, up to 32-bytes-le.
    * @return The uncompressed serialized commitment.
+   * @throws Exception Problem with native invocation
    */
-  public Bytes commit(Bytes32[] inputs);
+  public Bytes commit(Bytes[] scalars) throws Exception;
 
   /**
-   * Calculates the commitment hash for an array of inputs.
+   * Compute and serialise compress commitment to a dense vector of scalar values.
    *
-   * @param inputs An array of values to be hashed.
+   * @param scalars Serialised scalar values to commit to, up to 32-bytes-le.
    * @return The compressed serialized commitment used for calucating root Commitment.
+   * @throws Exception Problem with native invocation
    */
-  public Bytes32 commitRoot(Bytes32[] inputs);
-  /**
-   * Calculates the hash for an address and index.
-   *
-   * @param address Account address.
-   * @param index Index in storage.
-   * @return The trie-key hash
-   */
-  public Bytes32 trieKeyHash(Bytes address, Bytes32 index);
+  public Bytes32 commitAsCompressed(Bytes[] scalars) throws Exception;
 
-  public Bytes32 groupToField(Bytes commitment);
+  /**
+   * Update a commitment with a sparse vector of values.
+   *
+   * @param commitment Actual commitment value.
+   * @param indices List of vector's indices where values are updated.
+   * @param oldScalars List of previous scalar values.
+   * @param newScalars List of new scalar values.
+   * @return The uncompressed serialized updated commitment.
+   * @throws Exception Problem with native invocation
+   */
+  public Bytes updateSparse(
+      Optional<Bytes> commitment,
+      List<Byte> indices,
+      List<Bytes> oldScalars,
+      List<Bytes> newScalars)
+      throws Exception;
+
+  /**
+   * Computes the compressed serialised form of an uncompressed commitment.
+   *
+   * @param commitment Uncompressed serialised commitment to compress
+   * @return compressed commitment
+   * @throws Exception Problem with native invocation
+   */
+  public Bytes32 compress(Bytes commitment) throws Exception;
+  // public List<Bytes32> compressMany(List<Bytes> commitments) throws Exception;
+
+  /**
+   * Computes the scalar mapped from a commitment.
+   *
+   * @param commitment Uncompressed serialised commitment to hash.
+   * @return scalar
+   * @throws Exception Problem with native invocation
+   */
+  public Bytes32 hash(Bytes commitment) throws Exception;
+
+  /**
+   * Computes scalars mapped from a list of commitments.
+   *
+   * <p>Note that this method is highly optimised vectorised version of hash. It should be used as
+   * much as possible over multiple single hash.
+   *
+   * @param commitments List of uncompressed serialised commitment to hash.
+   * @return List of scalars
+   * @throws Exception Problem with native invocation
+   */
+  public Bytes32[] hashMany(List<Bytes> commitments) throws Exception;
 }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/hasher/PedersenHasher.java
@@ -17,8 +17,12 @@ package org.hyperledger.besu.ethereum.trie.verkle.hasher;
 
 import org.hyperledger.besu.nativelib.ipamultipoint.LibIpaMultipoint;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.MutableBytes;
 
 /**
  * A class responsible for hashing an array of Bytes32 using the pedersen commitment - multi scalar
@@ -27,90 +31,112 @@ import org.apache.tuweni.bytes.Bytes32;
  * <p>This class implements the Hasher interface and provides a method to commit multiple Bytes32
  * inputs using the pedersen commitment - multi scalar multiplication vector commitment algorithm.
  */
+@SuppressWarnings("null")
 public class PedersenHasher implements Hasher {
+  private static final Bytes defaultCommitment;
+  private static final Bytes32 defaultScalar;
 
-  // The amount of bytes that we will take from the input when `trieKeyHash` is
-  // called.
-  private static final int CHUNK_SIZE = 16;
-
-  // The input will always be 64 bytes once it is padded in `trieKeyHash `
-  // and since we are taking 16 bytes at a time we will create four chunks from
-  // the input.
-  // An extra chunk which has a constant value is added as a domain separator and
-  // length encoder,
-  // making the total number of chunks equal to five.
-  private static final int NUM_CHUNKS = 5;
-
-  /**
-   * Commits an array of Bytes32 using the pedersen commitment - multi scalar multiplication vector
-   * commitment algorithm.
-   *
-   * @param inputs An array of Bytes32 inputs to be committed.
-   * @return The resulting commitment serliazed as uncompressed eliptic curve element (64bytes).
-   */
-  @Override
-  public Bytes commit(Bytes32[] inputs) {
-    return Bytes.wrap(LibIpaMultipoint.commit(Bytes.concatenate(inputs).toArray()));
+  static {
+    // TODO: include defaults in LibIpaMultipoint
+    // defaultCommitment = Bytes.wrap(LibIpaMultipoint.defaultCommitment());
+    // defaultScalar = Bytes32.wrap(LibIpaMultipoint.defaultScalar());
+    defaultCommitment =
+        Bytes.concatenate(Bytes32.ZERO, Bytes32.rightPad(Bytes.fromHexString("0x01")));
+    defaultScalar = Bytes32.ZERO;
   }
 
-  /**
-   * @param inputs An array of Bytes32 inputs to be committed.
-   * @return The result is commitment as compressed eliptic curve element (32bytes). This is needed
-   *     to computing root Commitment.
-   */
   @Override
-  public Bytes32 commitRoot(final Bytes32[] inputs) {
-    return Bytes32.wrap(LibIpaMultipoint.commitRoot(Bytes.concatenate(inputs).toArray()));
+  public Bytes getDefaultCommitment() {
+    return defaultCommitment;
   }
 
-  /**
-   * @param input Uncompressed serialized commitment (64bytes)
-   * @return return Fr, to be used in pared commitment.
-   */
   @Override
-  public Bytes32 groupToField(Bytes input) {
-    return Bytes32.wrap(LibIpaMultipoint.groupToField(input.toArray()));
+  public Bytes32 getDefaultScalar() {
+    return defaultScalar;
   }
 
-  /**
-   * Calculates the hash for an address and index.
-   *
-   * @param address Account address.
-   * @param index Index in storage.
-   * @return The trie-key hash
-   */
   @Override
-  public Bytes32 trieKeyHash(Bytes address, Bytes32 index) {
+  public Bytes commit(Bytes[] scalars) throws Exception {
+    return Bytes.wrap(LibIpaMultipoint.commit(prepareScalars(scalars).toArray()));
+  }
 
-    // Reverse the index so that it is in little endian format
-    final Bytes32 indexLE = Bytes32.wrap(index.reverse());
+  @Override
+  public Bytes32 commitAsCompressed(Bytes[] scalars) throws Exception {
+    return Bytes32.wrap(LibIpaMultipoint.commitAsCompressed(prepareScalars(scalars).toArray()));
+  }
 
-    // Pad the address so that it is 32 bytes
-    final Bytes32 addr = Bytes32.leftPad(address);
-    final Bytes input = Bytes.concatenate(addr, indexLE);
-
-    final Bytes32[] chunks = new Bytes32[NUM_CHUNKS];
-
-    // Set the first chunk which is always 2 + 256 * 64
-    chunks[0] = Bytes32.rightPad(Bytes.of(2, 64));
-
-    // Given input is 64 bytes, we create exactly 4 chunks of 16 bytes each
-    // The chunks are then padded to 32 bytes since the commit methods requires 32
-    // byte scalars.
-    for (int i = 0; i < NUM_CHUNKS - 1; i++) {
-      // Slice input into 16 byte segments
-      Bytes chunk = input.slice(i * CHUNK_SIZE, CHUNK_SIZE);
-      // Pad each chunk to make it 32 bytes
-      chunks[i + 1] = Bytes32.rightPad(chunk);
+  @Override
+  public Bytes updateSparse(
+      final Optional<Bytes> commitment,
+      final List<Byte> indices,
+      final List<Bytes> oldScalars,
+      final List<Bytes> newScalars)
+      throws Exception {
+    Bytes cmnt = commitment.orElse(defaultCommitment);
+    byte[] idx = new byte[indices.size()];
+    for (int i = 0; i < indices.size(); i++) {
+      idx[i] = (byte) indices.get(i);
     }
+    return Bytes.wrap(
+        LibIpaMultipoint.updateSparse(
+            cmnt.toArray(),
+            idx,
+            prepareScalars(oldScalars.toArray(new Bytes[oldScalars.size()])).toArray(),
+            prepareScalars(newScalars.toArray(new Bytes[newScalars.size()])).toArray()));
+  }
 
-    final Bytes hashBE =
-        Bytes.wrap(LibIpaMultipoint.commitRoot(Bytes.concatenate(chunks).toArray()));
+  @Override
+  public Bytes32 compress(final Bytes commitment) throws Exception {
+    return Bytes32.wrap(LibIpaMultipoint.compress(commitment.toArray()));
+  }
 
-    // commitRoot returns the hash in big endian format, so we reverse it to get it
-    // in little endian
-    // format. When we migrate to using `groupToField`, this reverse will not be
-    // needed.
-    return Bytes32.wrap(hashBE.reverse());
+  // @Override
+  // public Bytes32 compressMany(final Bytes commitment) throws Exception {
+  //   if ( commitment.size != 64 ) { throw new IllegalArgumentException(); }
+  //   return Bytes32.wrap(LibIpaMultipoint.compressCommitment(commitment.toArray()));
+  // }
+
+  @Override
+  public Bytes32 hash(Bytes commitment) throws Exception {
+    return Bytes32.wrap(LibIpaMultipoint.hash(commitment.toArray()));
+  }
+
+  @Override
+  public Bytes32[] hashMany(List<Bytes> commitments) throws Exception {
+    Bytes input = prepareCommitments(commitments.toArray(new Bytes[commitments.size()]));
+    byte[] rawScalars = LibIpaMultipoint.hashMany(input.toArray());
+    Bytes32[] scalars = new Bytes32[rawScalars.length / 32];
+    for (int i = 0; i < scalars.length; i++) {
+      scalars[i] = Bytes32.wrap(rawScalars, i * 32);
+    }
+    return scalars;
+  }
+
+  // Protected methods
+
+  Bytes rightPadInput(int size, Bytes[] inputs) throws Exception {
+    MutableBytes result = MutableBytes.create(inputs.length * size);
+    for (int i = 0; i < inputs.length; i++) {
+      int offset = i * size;
+      if (inputs[i].size() > size) {
+        throw new IllegalArgumentException();
+      }
+      result.set(offset, inputs[i]);
+    }
+    return result;
+  }
+
+  Bytes prepareScalars(Bytes[] inputs) throws Exception {
+    if (inputs == null || inputs.length == 0) {
+      throw new IllegalArgumentException();
+    }
+    return rightPadInput(32, inputs);
+  }
+
+  Bytes prepareCommitments(Bytes[] inputs) throws Exception {
+    if (inputs == null || inputs.length == 0) {
+      throw new IllegalArgumentException();
+    }
+    return rightPadInput(64, inputs);
   }
 }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/BranchNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/BranchNode.java
@@ -217,6 +217,7 @@ public abstract class BranchNode<V> implements Node<V> {
   public void markClean() {
     dirty = false;
   }
+
   /**
    * Checks if the node is dirty, indicating that it needs to be persisted.
    *

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/LeafNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/LeafNode.java
@@ -37,6 +37,11 @@ public class LeafNode<V> implements Node<V> {
   private final V value; // Value associated with the node
   private Optional<Bytes> encodedValue = Optional.empty(); // Encoded value
   private final Function<V, Bytes> valueSerializer; // Serializer function for the value
+  // private final Bytes defaultValue = Bytes.fromHexString("0x00");
+
+  // For commitment updates, we need previously committed values.
+  private final Optional<V> committedValue;
+
   private boolean dirty = true; // not persisted
 
   /**
@@ -48,6 +53,7 @@ public class LeafNode<V> implements Node<V> {
   public LeafNode(final Bytes location, final V value) {
     this.location = Optional.of(location);
     this.value = value;
+    committedValue = Optional.empty();
     this.valueSerializer = val -> (Bytes) val;
   }
 
@@ -60,6 +66,20 @@ public class LeafNode<V> implements Node<V> {
   public LeafNode(final Optional<Bytes> location, final V value) {
     this.location = location;
     this.value = value;
+    committedValue = Optional.empty();
+    this.valueSerializer = val -> (Bytes) val;
+  }
+
+  /**
+   * Constructs a new LeafNode with optional location, value.
+   *
+   * @param location The location of the node in the tree (Optional).
+   * @param value The value associated with the node.
+   */
+  public LeafNode(final Optional<Bytes> location, final V value, final Optional<V> committedValue) {
+    this.location = location;
+    this.value = value;
+    this.committedValue = committedValue;
     this.valueSerializer = val -> (Bytes) val;
   }
 
@@ -94,6 +114,16 @@ public class LeafNode<V> implements Node<V> {
   @Override
   public Optional<V> getValue() {
     return Optional.ofNullable(value);
+  }
+
+  /**
+   * Get the value associated with the node.
+   *
+   * @return An optional containing the value of the node if available.
+   */
+  @Override
+  public Optional<V> getCommittedValue() {
+    return committedValue;
   }
 
   /**
@@ -146,6 +176,15 @@ public class LeafNode<V> implements Node<V> {
   @Override
   public void markClean() {
     dirty = false;
+  }
+
+  /**
+   * Checks if the node is dirty, indicating that it needs to be persisted.
+   *
+   * @return `true` if the node is marked as dirty, `false` otherwise.
+   */
+  public boolean isCommitted() {
+    return committedValue.isPresent();
   }
 
   /**

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/Node.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/Node.java
@@ -74,6 +74,15 @@ public interface Node<V> {
   }
 
   /**
+   * Get the value associated with the node.
+   *
+   * @return An optional containing the value of the node if available.
+   */
+  default Optional<V> getCommittedValue() {
+    return Optional.empty();
+  }
+
+  /**
    * Get the hash associated with the node.
    *
    * @return An optional containing the hash of the node if available.

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StemNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StemNode.java
@@ -42,6 +42,7 @@ public class StemNode<V> extends BranchNode<V> {
   private final Optional<Bytes> leftCommitment;
   private final Optional<Bytes32> rightHash;
   private final Optional<Bytes> rightCommitment;
+
   private Optional<Bytes> encodedValue = Optional.empty();
 
   /**

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/HashVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/HashVisitor.java
@@ -21,6 +21,8 @@ import org.hyperledger.besu.ethereum.trie.verkle.node.InternalNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.Node;
 import org.hyperledger.besu.ethereum.trie.verkle.node.StemNode;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -49,23 +51,45 @@ public class HashVisitor<V extends Bytes> implements PathNodeVisitor<V> {
         && internalNode.getCommitment().isPresent()) {
       return internalNode;
     }
+
+    List<Byte> indices = new ArrayList<Byte>();
+    List<Bytes> oldScalars = new ArrayList<Bytes>();
+    List<Bytes> newScalars = new ArrayList<Bytes>();
     int size = InternalNode.maxChild();
-    Bytes32[] hashes = new Bytes32[size];
+
     for (int i = 0; i < size; i++) {
       byte index = (byte) i;
       Node<V> child = internalNode.child(index);
       Bytes nextLocation = Bytes.concatenate(location, Bytes.of(index));
       Node<V> updatedChild = child.accept(this, nextLocation);
       internalNode.replaceChild(index, updatedChild);
-      hashes[i] = updatedChild.getHash().get();
+
+      Bytes32 oldHash = child.getHash().orElse(hasher.getDefaultScalar());
+      Bytes32 newHash = updatedChild.getHash().orElse(hasher.getDefaultScalar());
+      if (oldHash != newHash) {
+        indices.add((Byte) index);
+        oldScalars.add((Bytes) oldHash);
+        newScalars.add((Bytes) newHash);
+      }
     }
+    if (indices.size() == 0) {
+      return internalNode;
+    }
+
     final Bytes32 hash;
-    if (location.isEmpty()) {
-      hash = hasher.commitRoot(hashes);
-    } else {
-      hash = hasher.groupToField(hasher.commit(hashes));
+    Optional<Bytes> previousCommitment = internalNode.getCommitment();
+    try {
+      Bytes commitment = hasher.updateSparse(previousCommitment, indices, oldScalars, newScalars);
+      // Should modify soon
+      if (location.isEmpty()) { // Root node
+        hash = hasher.compress(commitment);
+      } else { // Proper internal node
+        hash = hasher.hash(commitment);
+      }
+      return internalNode.replaceHash(hash, commitment);
+    } catch (Exception e) {
+      return internalNode;
     }
-    return internalNode.replaceHash(hash, hash); // commitment should be different
   }
 
   /**
@@ -82,29 +106,84 @@ public class HashVisitor<V extends Bytes> implements PathNodeVisitor<V> {
         && stemNode.getCommitment().isPresent()) {
       return stemNode;
     }
-    int size = StemNode.maxChild();
-    Bytes32[] hashes = new Bytes32[4];
-    Bytes32[] leftValues = new Bytes32[size];
-    Bytes32[] rightValues = new Bytes32[size];
-    for (int i = 0; i < size / 2; i++) {
-      byte index = (byte) i;
-      Node<V> child = stemNode.child(index);
-      leftValues[2 * i] = getLowValue(child.getValue());
-      leftValues[2 * i + 1] = getHighValue(child.getValue());
+
+    Optional<Bytes> leftCommitment = getSubCommitment(0, stemNode);
+    Optional<Bytes> rightCommitment = getSubCommitment(1, stemNode);
+    Optional<Bytes> oldCommitment = stemNode.getCommitment();
+    Bytes commitment;
+    Bytes32 leftHash = hasher.getDefaultScalar();
+    Bytes32 rightHash = hasher.getDefaultScalar();
+    if (oldCommitment.isPresent()) { // Update subcommitments only
+      List<Byte> indices = new ArrayList<Byte>();
+      List<Bytes> oldScalars = new ArrayList<Bytes>();
+      List<Bytes> newScalars = new ArrayList<Bytes>();
+      if (leftCommitment.isPresent()) {
+        indices.add((Byte) (byte) 2);
+        Optional<Bytes> maybeOldLeft = stemNode.getLeftCommitment();
+        Bytes oldLeft = hasher.getDefaultScalar();
+        if (maybeOldLeft.isPresent()) {
+          try {
+            oldLeft = hasher.hash(maybeOldLeft.get());
+          } catch (Exception e) {
+            // Should let it bubble up
+          }
+        }
+        oldScalars.add(oldLeft);
+        try {
+          leftHash = hasher.hash(leftCommitment.get());
+        } catch (Exception e) {
+          // Should let it bubble up
+        }
+        newScalars.add(leftHash);
+      }
+      if (rightCommitment.isPresent()) {
+        indices.add((Byte) (byte) 3);
+        Optional<Bytes> maybeOldRight = stemNode.getRightCommitment();
+        Bytes oldRight = hasher.getDefaultScalar();
+        if (maybeOldRight.isPresent()) {
+          try {
+            oldRight = hasher.hash(maybeOldRight.get());
+          } catch (Exception e) {
+            // Should let it bubble up
+          }
+        }
+        oldScalars.add(oldRight);
+        try {
+          rightHash = hasher.hash(rightCommitment.get());
+        } catch (Exception e) {
+          // Should let it bubble up
+        }
+        newScalars.add(rightHash);
+      }
+      try {
+        commitment = hasher.updateSparse(oldCommitment, indices, oldScalars, newScalars);
+      } catch (Exception e) {
+        commitment = hasher.getDefaultCommitment();
+      }
+    } else { // commit also extension marker and stem
+      Bytes[] hashes = new Bytes[4];
+      hashes[0] = Bytes.of(1); // extension marker
+      hashes[1] = stemNode.getStem();
+      hashes[2] = leftHash;
+      hashes[3] = rightHash;
+      try {
+        commitment = hasher.commit(hashes);
+      } catch (Exception e) {
+        // Should bubble up
+        commitment = hasher.getDefaultCommitment();
+      }
     }
-    for (int i = size / 2; i < size; i++) {
-      byte index = (byte) i;
-      Node<V> child = stemNode.child(index);
-      rightValues[2 * i - size] = getLowValue(child.getValue());
-      rightValues[2 * i + 1 - size] = getHighValue(child.getValue());
+    Bytes32 hash;
+    try {
+      hash = hasher.hash(commitment);
+    } catch (Exception e) {
+      // Should bubble up
+      hash = hasher.getDefaultScalar();
     }
-    hashes[0] = Bytes32.rightPad(Bytes.of(1)); // extension marker
-    hashes[1] = Bytes32.rightPad(stemNode.getStem());
-    hashes[2] = hasher.groupToField(hasher.commit(leftValues));
-    hashes[3] = hasher.groupToField(hasher.commit(rightValues));
-    final Bytes32 hash = hasher.groupToField(hasher.commit(hashes));
     return stemNode.replaceHash(
-        hash, hash, hashes[2], hashes[2], hashes[3], hashes[3]); // commitment should be different
+        hash, commitment,
+        leftHash, leftCommitment.orElse(hasher.getDefaultCommitment()),
+        rightHash, rightCommitment.orElse(hasher.getDefaultCommitment()));
   }
 
   /**
@@ -113,13 +192,13 @@ public class HashVisitor<V extends Bytes> implements PathNodeVisitor<V> {
    * @param value The optional value.
    * @return The low value.
    */
-  Bytes32 getLowValue(Optional<V> value) {
-    // Low values have a flag at bit 128.
-    return value
-        .map(
-            (v) ->
-                Bytes32.rightPad(Bytes.concatenate(Bytes32.rightPad(v).slice(0, 16), Bytes.of(1))))
-        .orElse(Bytes32.ZERO);
+  Bytes getLowValue(Optional<V> value) {
+    // Low values have a 1 flag at bit 128.
+    if (value.isPresent()) {
+      return Bytes.concatenate(value.get().slice(0, 16), Bytes.of((byte) 1));
+    } else {
+      return Bytes.wrap(new byte[17]);
+    }
   }
 
   /**
@@ -128,9 +207,51 @@ public class HashVisitor<V extends Bytes> implements PathNodeVisitor<V> {
    * @param value The optional value.
    * @return The high value.
    */
-  Bytes32 getHighValue(Optional<V> value) {
-    return value
-        .map((v) -> Bytes32.rightPad(Bytes32.rightPad(v).slice(16, 16)))
-        .orElse(Bytes32.ZERO);
+  Bytes getHighValue(Optional<V> value) {
+    // High values have a 0 flag at bit 128.
+    if (value.isPresent()) {
+      return Bytes.concatenate(value.get().slice(16, 16), Bytes.of((byte) 0));
+    } else {
+      return Bytes.wrap(new byte[17]);
+    }
+  }
+
+  Optional<Bytes> getSubCommitment(int subIndex, StemNode<V> stemNode) {
+    // Get sparse vector to updating subcommitments
+    List<Byte> indices = new ArrayList<Byte>();
+    List<Bytes> oldScalars = new ArrayList<Bytes>();
+    List<Bytes> newScalars = new ArrayList<Bytes>();
+    int size = StemNode.maxChild();
+    int offset = subIndex * (size / 2);
+
+    for (int i = offset; i < (offset + size / 2); i++) {
+      Node<V> child = stemNode.child((byte) i);
+      Optional<V> value = child.getValue();
+      Optional<V> committedValue = child.getCommittedValue();
+      Bytes lowValue = getLowValue(value);
+      Bytes lowCommitted = getLowValue(committedValue);
+      Bytes highValue = getHighValue(value);
+      Bytes highCommitted = getHighValue(committedValue);
+      if (!lowValue.equals(lowCommitted) || !highValue.equals(highCommitted)) {
+        indices.add((Byte) (byte) (2 * (i - offset)));
+        oldScalars.add(lowCommitted);
+        newScalars.add(lowValue);
+        indices.add((Byte) (byte) (2 * (i + 1 - offset)));
+        oldScalars.add(highCommitted);
+        newScalars.add(highValue);
+      }
+    }
+    Optional<Bytes> oldCommitment =
+        subIndex == 0 ? stemNode.getLeftCommitment() : stemNode.getRightCommitment();
+    if (indices.size() == 0) {
+      return oldCommitment;
+    } else {
+      try {
+        return Optional.of(hasher.updateSparse(oldCommitment, indices, oldScalars, newScalars));
+      } catch (Exception e) {
+        // Should bubble up
+        return Optional.empty();
+      }
+    }
   }
 }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/PutVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/PutVisitor.java
@@ -117,7 +117,7 @@ public class PutVisitor<V> implements PathNodeVisitor<V> {
     LeafNode<V> newNode;
     oldValue = leafNode.getValue();
     if (oldValue != value) {
-      newNode = new LeafNode<V>(leafNode.getLocation(), value);
+      newNode = new LeafNode<V>(leafNode.getLocation(), value, oldValue);
       newNode.markDirty();
     } else {
       newNode = leafNode;


### PR DESCRIPTION
## PR description

This PR introduces HashVisitor that makes use of update commitments instead of full vector commits.

It is still a draft as:

1. Tests are not yet passing
2. We should keep previous HashVisitor as well for comparaison.