### PR TITLE
ADD: nullity bitmap and hashes in storage

### DIFF
--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/SimpleBatchedVerkleTrie.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/SimpleBatchedVerkleTrie.java
@@ -35,7 +35,7 @@ import org.apache.tuweni.bytes.Bytes32;
  * @param <V> The type of values in the Verkle Trie.
  */
 public class SimpleBatchedVerkleTrie<K extends Bytes, V extends Bytes>
-    extends SimpleVerkleTrie<K, V> implements VerkleTrie<K, V> {
+    extends SimpleVerkleTrie<K, V> {
 
   private final VerkleTrieBatchHasher batchProcessor;
 

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/VerkleTrieBatchHasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/VerkleTrieBatchHasher.java
@@ -44,9 +44,7 @@ import org.apache.tuweni.bytes.Bytes32;
 /**
  * Processes batches of trie nodes for efficient hashing.
  *
- * <p>
- * This class manages the batching and hashing of trie nodes to optimize
- * performance.
+ * <p>This class manages the batching and hashing of trie nodes to optimize performance.
  */
 public class VerkleTrieBatchHasher {
 
@@ -54,15 +52,15 @@ public class VerkleTrieBatchHasher {
   private static final int MAX_BATCH_SIZE = 1000; // Maximum number of nodes in a batch
   private static final Bytes[] EMPTY_ARRAY_TEMPLATE = new Bytes[0];
   private final Hasher hasher = new PedersenHasher(); // Hasher for node hashing
-  private final Map<Bytes, Node<?>> updatedNodes = new HashMap<>(); // Map to hold nodes for batching
+  private final Map<Bytes, Node<?>> updatedNodes =
+      new HashMap<>(); // Map to hold nodes for batching
 
   /**
-   * Adds a node for future batching. If the node is a NullNode or NullLeafNode
-   * and the location is
+   * Adds a node for future batching. If the node is a NullNode or NullLeafNode and the location is
    * not empty, it removes the node from the batch.
    *
    * @param location The location of the node.
-   * @param node     The node to add.
+   * @param node The node to add.
    */
   public void addNodeToBatch(final Optional<Bytes> location, final Node<?> node) {
     if ((node instanceof NullNode<?> || node instanceof NullLeafNode<?>)
@@ -83,8 +81,7 @@ public class VerkleTrieBatchHasher {
   }
 
   /**
-   * Processes the nodes in batches. Sorts the nodes by their location and hashes
-   * them in batches.
+   * Processes the nodes in batches. Sorts the nodes by their location and hashes them in batches.
    * Clears the batch after processing.
    */
   public void calculateStateRoot() {
@@ -92,7 +89,8 @@ public class VerkleTrieBatchHasher {
       return;
     }
 
-    final List<Map.Entry<Bytes, Node<?>>> sortedNodesByLocation = new ArrayList<>(updatedNodes.entrySet());
+    final List<Map.Entry<Bytes, Node<?>>> sortedNodesByLocation =
+        new ArrayList<>(updatedNodes.entrySet());
     sortedNodesByLocation.sort(
         (entry1, entry2) -> Integer.compare(entry2.getKey().size(), entry1.getKey().size()));
 
@@ -154,7 +152,8 @@ public class VerkleTrieBatchHasher {
             "Executing batch hashing for {} commitments of stem (left/right) and internal nodes.",
             commitments.size());
     Iterator<Bytes> commitmentsIterator = new ArrayList<>(commitments).iterator();
-    Iterator<Bytes32> hashesIterator = hasher.hashMany(commitments.toArray(EMPTY_ARRAY_TEMPLATE)).iterator();
+    Iterator<Bytes32> hashesIterator =
+        hasher.hashMany(commitments.toArray(EMPTY_ARRAY_TEMPLATE)).iterator();
 
     // reset commitments list for stem
     commitments.clear();

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/VerkleTrieBatchHasher.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/VerkleTrieBatchHasher.java
@@ -44,7 +44,9 @@ import org.apache.tuweni.bytes.Bytes32;
 /**
  * Processes batches of trie nodes for efficient hashing.
  *
- * <p>This class manages the batching and hashing of trie nodes to optimize performance.
+ * <p>
+ * This class manages the batching and hashing of trie nodes to optimize
+ * performance.
  */
 public class VerkleTrieBatchHasher {
 
@@ -52,15 +54,15 @@ public class VerkleTrieBatchHasher {
   private static final int MAX_BATCH_SIZE = 1000; // Maximum number of nodes in a batch
   private static final Bytes[] EMPTY_ARRAY_TEMPLATE = new Bytes[0];
   private final Hasher hasher = new PedersenHasher(); // Hasher for node hashing
-  private final Map<Bytes, Node<?>> updatedNodes =
-      new HashMap<>(); // Map to hold nodes for batching
+  private final Map<Bytes, Node<?>> updatedNodes = new HashMap<>(); // Map to hold nodes for batching
 
   /**
-   * Adds a node for future batching. If the node is a NullNode or NullLeafNode and the location is
+   * Adds a node for future batching. If the node is a NullNode or NullLeafNode
+   * and the location is
    * not empty, it removes the node from the batch.
    *
    * @param location The location of the node.
-   * @param node The node to add.
+   * @param node     The node to add.
    */
   public void addNodeToBatch(final Optional<Bytes> location, final Node<?> node) {
     if ((node instanceof NullNode<?> || node instanceof NullLeafNode<?>)
@@ -81,7 +83,8 @@ public class VerkleTrieBatchHasher {
   }
 
   /**
-   * Processes the nodes in batches. Sorts the nodes by their location and hashes them in batches.
+   * Processes the nodes in batches. Sorts the nodes by their location and hashes
+   * them in batches.
    * Clears the batch after processing.
    */
   public void calculateStateRoot() {
@@ -89,8 +92,7 @@ public class VerkleTrieBatchHasher {
       return;
     }
 
-    final List<Map.Entry<Bytes, Node<?>>> sortedNodesByLocation =
-        new ArrayList<>(updatedNodes.entrySet());
+    final List<Map.Entry<Bytes, Node<?>>> sortedNodesByLocation = new ArrayList<>(updatedNodes.entrySet());
     sortedNodesByLocation.sort(
         (entry1, entry2) -> Integer.compare(entry2.getKey().size(), entry1.getKey().size()));
 
@@ -108,7 +110,8 @@ public class VerkleTrieBatchHasher {
           }
           if (location.isEmpty()) {
             // We will end up updating the root node. Once all the batching is finished,
-            // we will update the previous states of the nodes by setting them to the new ones.
+            // we will update the previous states of the nodes by setting them to the new
+            // ones.
             calculateRootInternalNodeHash((InternalNode<?>) node);
             updatedNodes.forEach(
                 (__, n) -> {
@@ -151,8 +154,7 @@ public class VerkleTrieBatchHasher {
             "Executing batch hashing for {} commitments of stem (left/right) and internal nodes.",
             commitments.size());
     Iterator<Bytes> commitmentsIterator = new ArrayList<>(commitments).iterator();
-    Iterator<Bytes32> hashesIterator =
-        hasher.hashMany(commitments.toArray(EMPTY_ARRAY_TEMPLATE)).iterator();
+    Iterator<Bytes32> hashesIterator = hasher.hashMany(commitments.toArray(EMPTY_ARRAY_TEMPLATE)).iterator();
 
     // reset commitments list for stem
     commitments.clear();
@@ -182,8 +184,9 @@ public class VerkleTrieBatchHasher {
   }
 
   private void calculateRootInternalNodeHash(final InternalNode<?> internalNode) {
-    final Bytes32 hash = Bytes32.wrap(getRootNodeCommitments(internalNode).get(0));
-    internalNode.replaceHash(hash, hash);
+    final Bytes commitment = getRootNodeCommitments(internalNode).get(0);
+    final Bytes32 hash = hasher.compress(commitment);
+    internalNode.replaceHash(hash, commitment);
   }
 
   private void calculateStemNodeHashes(
@@ -226,9 +229,11 @@ public class VerkleTrieBatchHasher {
       Node<?> node = stemNode.child((byte) idx);
 
       Optional<Bytes> oldValue = node.getPrevious().map(Bytes.class::cast);
-      // We should not recalculate a node if it is persisted and has not undergone an update since
+      // We should not recalculate a node if it is persisted and has not undergone an
+      // update since
       // its last save.
-      // If a child does not have a previous value, it means that it is a new node and we must
+      // If a child does not have a previous value, it means that it is a new node and
+      // we must
       // therefore recalculate it.
       if (!(node instanceof StoredNode<?>) && (oldValue.isEmpty() || node.isDirty())) {
         if (idx < halfSize) {
@@ -297,9 +302,11 @@ public class VerkleTrieBatchHasher {
     for (int i = 0; i < size; i++) {
       final Node<?> node = internalNode.child((byte) i);
       Optional<Bytes> oldValue = node.getPrevious().map(Bytes.class::cast);
-      // We should not recalculate a node if it is persisted and has not undergone an update since
+      // We should not recalculate a node if it is persisted and has not undergone an
+      // update since
       // its last save.
-      // If a child does not have a previous value, it means that it is a new node and we must
+      // If a child does not have a previous value, it means that it is a new node and
+      // we must
       // therefore recalculate it.
       if (!(node instanceof StoredNode<?>) && (oldValue.isEmpty() || node.isDirty())) {
         indices.add((byte) i);
@@ -315,12 +322,12 @@ public class VerkleTrieBatchHasher {
   private List<Bytes> getRootNodeCommitments(InternalNode<?> internalNode) {
     int size = InternalNode.maxChild();
     final List<Bytes> commitmentsHashes = new ArrayList<>();
-    final List<Bytes> newValues = new ArrayList<>();
+    final List<Bytes32> newValues = new ArrayList<>();
     for (int i = 0; i < size; i++) {
       final Node<?> node = internalNode.child((byte) i);
       newValues.add(node.getHash().get());
     }
-    commitmentsHashes.add(hasher.commitRoot(newValues.toArray(new Bytes[] {})));
+    commitmentsHashes.add(hasher.commit(newValues.toArray(new Bytes32[] {})));
     return commitmentsHashes;
   }
 }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/factory/StoredNodeFactory.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/factory/StoredNodeFactory.java
@@ -19,8 +19,8 @@ import org.hyperledger.besu.ethereum.trie.NodeLoader;
 import org.hyperledger.besu.ethereum.trie.verkle.node.InternalNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.LeafNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.Node;
-import org.hyperledger.besu.ethereum.trie.verkle.node.NullNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.NullLeafNode;
+import org.hyperledger.besu.ethereum.trie.verkle.node.NullNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.StemNode;
 import org.hyperledger.besu.ethereum.trie.verkle.node.StoredNode;
 
@@ -51,10 +51,9 @@ public class StoredNodeFactory<V> implements NodeFactory<V> {
   private final Function<Bytes, V> valueDeserializer;
 
   /**
-   * Creates a new StoredNodeFactory with the given node loader and value
-   * deserializer.
+   * Creates a new StoredNodeFactory with the given node loader and value deserializer.
    *
-   * @param nodeLoader        The loader for retrieving stored nodes.
+   * @param nodeLoader The loader for retrieving stored nodes.
    * @param valueDeserializer The function to deserialize values from Bytes.
    */
   public StoredNodeFactory(NodeLoader nodeLoader, Function<Bytes, V> valueDeserializer) {
@@ -66,10 +65,9 @@ public class StoredNodeFactory<V> implements NodeFactory<V> {
    * Retrieves a Verkle Trie node from stored data based on the location and hash.
    *
    * @param location Node's location
-   * @param hash     Node's hash
-   * @return An optional containing the retrieved node, or an empty optional if
-   *         the node is not
-   *         found.
+   * @param hash Node's hash
+   * @return An optional containing the retrieved node, or an empty optional if the node is not
+   *     found.
    */
   @Override
   public Optional<Node<V>> retrieve(final Bytes location, final Bytes32 hash) {
@@ -103,7 +101,6 @@ public class StoredNodeFactory<V> implements NodeFactory<V> {
       }
     }
     return isNull;
-
   }
 
   private List<Bytes32> decodeScalars(List<Boolean> isNull, Bytes values) {
@@ -150,9 +147,9 @@ public class StoredNodeFactory<V> implements NodeFactory<V> {
   /**
    * Creates a internalNode using the provided location, hash, and path.
    *
-   * @param location      The location of the internalNode.
+   * @param location The location of the internalNode.
    * @param encodedValues List of Bytes values retrieved from storage.
-   * @param hash          Node's hash value.
+   * @param hash Node's hash value.
    * @return A internalNode instance.
    */
   InternalNode<V> createInternalNode(Bytes location, Bytes encodedValues, Bytes32 hash) {
@@ -182,9 +179,9 @@ public class StoredNodeFactory<V> implements NodeFactory<V> {
   /**
    * Creates a BranchNode using the provided location, hash, and path.
    *
-   * @param location      The location of the BranchNode.
+   * @param location The location of the BranchNode.
    * @param encodedValues List of Bytes values retrieved from storage.
-   * @param hash          Node's hash value.
+   * @param hash Node's hash value.
    * @return A BranchNode instance.
    */
   StemNode<V> createStemNode(Bytes location, Bytes encodedValues, Bytes32 hash) {
@@ -215,16 +212,21 @@ public class StoredNodeFactory<V> implements NodeFactory<V> {
       }
     }
     return new StemNode<V>(
-        location, stem,
-        hash, commitment,
-        leftHash, leftCommitment, rightHash, rightCommitment,
+        location,
+        stem,
+        hash,
+        commitment,
+        leftHash,
+        leftCommitment,
+        rightHash,
+        rightCommitment,
         children);
   }
 
   /**
    * Creates a LeafNode using the provided location, path, and value.
    *
-   * @param key          The key of the LeafNode.
+   * @param key The key of the LeafNode.
    * @param encodedValue Leaf value retrieved from storage.
    * @return A LeafNode instance.
    */

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/BranchNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/BranchNode.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.MutableBytes;
 
 /**
  * Represents a branch node in the Verkle Trie.
@@ -39,10 +40,10 @@ public abstract class BranchNode<V> extends Node<V> {
   /**
    * Constructs a new BranchNode with location, hash, path, and children.
    *
-   * @param location The location in the tree.
-   * @param hash Node's vector commitment's hash.
+   * @param location   The location in the tree.
+   * @param hash       Node's vector commitment's hash.
    * @param commitment Node's vector commitment.
-   * @param children The list of children nodes.
+   * @param children   The list of children nodes.
    */
   public BranchNode(
       final Bytes location,
@@ -58,13 +59,14 @@ public abstract class BranchNode<V> extends Node<V> {
   }
 
   /**
-   * Constructs a new BranchNode with optional location, optional hash, optional commitment and
+   * Constructs a new BranchNode with optional location, optional hash, optional
+   * commitment and
    * children.
    *
-   * @param location The optional location in the tree.
-   * @param hash The optional vector commitment of children's commitments.
+   * @param location   The optional location in the tree.
+   * @param hash       The optional vector commitment of children's commitments.
    * @param commitment Node's optional vector commitment.
-   * @param children The list of children nodes.
+   * @param children   The list of children nodes.
    */
   public BranchNode(
       final Optional<Bytes> location,
@@ -95,7 +97,8 @@ public abstract class BranchNode<V> extends Node<V> {
   }
 
   /**
-   * Constructs a new BranchNode with optional location and path, initializing children to
+   * Constructs a new BranchNode with optional location and path, initializing
+   * children to
    * NullNodes.
    *
    * @param location The optional location in the tree.
@@ -132,7 +135,7 @@ public abstract class BranchNode<V> extends Node<V> {
    * Accepts a visitor for path-based operations on the node.
    *
    * @param visitor The path node visitor.
-   * @param path The path associated with a node.
+   * @param path    The path associated with a node.
    * @return The result of the visitor's operation.
    */
   @Override
@@ -160,7 +163,7 @@ public abstract class BranchNode<V> extends Node<V> {
   /**
    * Replaces the child node at a specified index with a new node.
    *
-   * @param index The index of the child node to replace.
+   * @param index     The index of the child node to replace.
    * @param childNode The new child node.
    */
   public void replaceChild(final byte index, final Node<V> childNode) {
@@ -206,6 +209,28 @@ public abstract class BranchNode<V> extends Node<V> {
   public abstract Bytes getEncodedValue();
 
   /**
+   * Get nullity bitmap
+   *
+   * @return Children's nullity bitmap
+   */
+  public Bytes getNullBitmap() {
+    int N = maxChild() / 8;
+    MutableBytes bitmap = MutableBytes.create(N);
+    for (int i = 0; i < N; i++) {
+      int mask = 128; // 1000 0000
+      int cur = 0;
+      for (int j = 8 * i; j < 8 * (i + 1); j++) {
+        if (child((byte) j).isNull()) {
+          cur |= mask;
+        }
+        mask = mask >> 1;
+      }
+      bitmap.set(i, (byte) cur);
+    }
+    return (Bytes) bitmap;
+  }
+
+  /**
    * Get the list of children nodes.
    *
    * @return The list of children nodes.
@@ -224,6 +249,7 @@ public abstract class BranchNode<V> extends Node<V> {
   public Optional<Bytes32> getPrevious() {
     return previous.map(Bytes32.class::cast);
   }
+
   /**
    * Generates a string representation of the branch node and its children.
    *
@@ -251,25 +277,23 @@ public abstract class BranchNode<V> extends Node<V> {
    */
   @Override
   public String toDot(Boolean showNullNodes) {
-    StringBuilder result =
-        new StringBuilder()
-            .append(getClass().getSimpleName())
-            .append(getLocation().orElse(Bytes.EMPTY))
-            .append(" [label=\"B: ")
-            .append(getLocation().orElse(Bytes.EMPTY))
-            .append("\n")
-            .append("Commitment: ")
-            .append(getCommitment().orElse(Bytes32.ZERO))
-            .append("\"]\n");
+    StringBuilder result = new StringBuilder()
+        .append(getClass().getSimpleName())
+        .append(getLocation().orElse(Bytes.EMPTY))
+        .append(" [label=\"B: ")
+        .append(getLocation().orElse(Bytes.EMPTY))
+        .append("\n")
+        .append("Commitment: ")
+        .append(getCommitment().orElse(Bytes32.ZERO))
+        .append("\"]\n");
 
     for (Node<V> child : getChildren()) {
-      String edgeString =
-          getClass().getSimpleName()
-              + getLocation().orElse(Bytes.EMPTY)
-              + " -> "
-              + child.getClass().getSimpleName()
-              + child.getLocation().orElse(Bytes.EMPTY)
-              + "\n";
+      String edgeString = getClass().getSimpleName()
+          + getLocation().orElse(Bytes.EMPTY)
+          + " -> "
+          + child.getClass().getSimpleName()
+          + child.getLocation().orElse(Bytes.EMPTY)
+          + "\n";
 
       if (showNullNodes || !result.toString().contains(edgeString)) {
         result.append(edgeString);

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/BranchNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/BranchNode.java
@@ -40,10 +40,10 @@ public abstract class BranchNode<V> extends Node<V> {
   /**
    * Constructs a new BranchNode with location, hash, path, and children.
    *
-   * @param location   The location in the tree.
-   * @param hash       Node's vector commitment's hash.
+   * @param location The location in the tree.
+   * @param hash Node's vector commitment's hash.
    * @param commitment Node's vector commitment.
-   * @param children   The list of children nodes.
+   * @param children The list of children nodes.
    */
   public BranchNode(
       final Bytes location,
@@ -59,14 +59,13 @@ public abstract class BranchNode<V> extends Node<V> {
   }
 
   /**
-   * Constructs a new BranchNode with optional location, optional hash, optional
-   * commitment and
+   * Constructs a new BranchNode with optional location, optional hash, optional commitment and
    * children.
    *
-   * @param location   The optional location in the tree.
-   * @param hash       The optional vector commitment of children's commitments.
+   * @param location The optional location in the tree.
+   * @param hash The optional vector commitment of children's commitments.
    * @param commitment Node's optional vector commitment.
-   * @param children   The list of children nodes.
+   * @param children The list of children nodes.
    */
   public BranchNode(
       final Optional<Bytes> location,
@@ -97,8 +96,7 @@ public abstract class BranchNode<V> extends Node<V> {
   }
 
   /**
-   * Constructs a new BranchNode with optional location and path, initializing
-   * children to
+   * Constructs a new BranchNode with optional location and path, initializing children to
    * NullNodes.
    *
    * @param location The optional location in the tree.
@@ -135,7 +133,7 @@ public abstract class BranchNode<V> extends Node<V> {
    * Accepts a visitor for path-based operations on the node.
    *
    * @param visitor The path node visitor.
-   * @param path    The path associated with a node.
+   * @param path The path associated with a node.
    * @return The result of the visitor's operation.
    */
   @Override
@@ -163,7 +161,7 @@ public abstract class BranchNode<V> extends Node<V> {
   /**
    * Replaces the child node at a specified index with a new node.
    *
-   * @param index     The index of the child node to replace.
+   * @param index The index of the child node to replace.
    * @param childNode The new child node.
    */
   public void replaceChild(final byte index, final Node<V> childNode) {
@@ -277,23 +275,25 @@ public abstract class BranchNode<V> extends Node<V> {
    */
   @Override
   public String toDot(Boolean showNullNodes) {
-    StringBuilder result = new StringBuilder()
-        .append(getClass().getSimpleName())
-        .append(getLocation().orElse(Bytes.EMPTY))
-        .append(" [label=\"B: ")
-        .append(getLocation().orElse(Bytes.EMPTY))
-        .append("\n")
-        .append("Commitment: ")
-        .append(getCommitment().orElse(Bytes32.ZERO))
-        .append("\"]\n");
+    StringBuilder result =
+        new StringBuilder()
+            .append(getClass().getSimpleName())
+            .append(getLocation().orElse(Bytes.EMPTY))
+            .append(" [label=\"B: ")
+            .append(getLocation().orElse(Bytes.EMPTY))
+            .append("\n")
+            .append("Commitment: ")
+            .append(getCommitment().orElse(Bytes32.ZERO))
+            .append("\"]\n");
 
     for (Node<V> child : getChildren()) {
-      String edgeString = getClass().getSimpleName()
-          + getLocation().orElse(Bytes.EMPTY)
-          + " -> "
-          + child.getClass().getSimpleName()
-          + child.getLocation().orElse(Bytes.EMPTY)
-          + "\n";
+      String edgeString =
+          getClass().getSimpleName()
+              + getLocation().orElse(Bytes.EMPTY)
+              + " -> "
+              + child.getClass().getSimpleName()
+              + child.getLocation().orElse(Bytes.EMPTY)
+              + "\n";
 
       if (showNullNodes || !result.toString().contains(edgeString)) {
         result.append(edgeString);

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/InternalNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/InternalNode.java
@@ -36,10 +36,10 @@ public class InternalNode<V> extends BranchNode<V> {
   /**
    * Constructs a new InternalNode with location, hash, path, and children.
    *
-   * @param location   The location in the tree.
-   * @param hash       Node's vector commitment's hash.
+   * @param location The location in the tree.
+   * @param hash Node's vector commitment's hash.
    * @param commitment Node's vector commitment.
-   * @param children   The list of children nodes.
+   * @param children The list of children nodes.
    */
   public InternalNode(
       final Bytes location,
@@ -51,8 +51,7 @@ public class InternalNode<V> extends BranchNode<V> {
   }
 
   /**
-   * Constructs a new InternalNode with optional location and path, initializing
-   * children to
+   * Constructs a new InternalNode with optional location and path, initializing children to
    * NullNodes.
    *
    * @param location The optional location in the tree.
@@ -65,7 +64,7 @@ public class InternalNode<V> extends BranchNode<V> {
    * Accepts a visitor for path-based operations on the node.
    *
    * @param visitor The path node visitor.
-   * @param path    The path associated with a node.
+   * @param path The path associated with a node.
    * @return The result of the visitor's operation.
    */
   @Override
@@ -87,7 +86,7 @@ public class InternalNode<V> extends BranchNode<V> {
   /**
    * Replace the vector commitment with a new one.
    *
-   * @param hash       The new vector commitment's hash to set.
+   * @param hash The new vector commitment's hash to set.
    * @param commitment The new vector commitment to set.
    * @return A new InternalNode with the updated vector commitment.
    */
@@ -155,22 +154,24 @@ public class InternalNode<V> extends BranchNode<V> {
    */
   @Override
   public String toDot(Boolean showNullNodes) {
-    StringBuilder result = new StringBuilder()
-        .append(getClass().getSimpleName())
-        .append(getLocation().orElse(Bytes.EMPTY))
-        .append(" [label=\"I: ")
-        .append(getLocation().orElse(Bytes.EMPTY))
-        .append("\nCommitment: ")
-        .append(getCommitment().orElse(Bytes32.ZERO))
-        .append("\"]\n");
+    StringBuilder result =
+        new StringBuilder()
+            .append(getClass().getSimpleName())
+            .append(getLocation().orElse(Bytes.EMPTY))
+            .append(" [label=\"I: ")
+            .append(getLocation().orElse(Bytes.EMPTY))
+            .append("\nCommitment: ")
+            .append(getCommitment().orElse(Bytes32.ZERO))
+            .append("\"]\n");
 
     for (Node<V> child : getChildren()) {
-      String edgeString = getClass().getSimpleName()
-          + getLocation().orElse(Bytes.EMPTY)
-          + " -> "
-          + child.getClass().getSimpleName()
-          + child.getLocation().orElse(Bytes.EMPTY)
-          + "\n";
+      String edgeString =
+          getClass().getSimpleName()
+              + getLocation().orElse(Bytes.EMPTY)
+              + " -> "
+              + child.getClass().getSimpleName()
+              + child.getLocation().orElse(Bytes.EMPTY)
+              + "\n";
 
       if (showNullNodes || !result.toString().contains(edgeString)) {
         result.append(edgeString);

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/LeafNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/LeafNode.java
@@ -39,7 +39,7 @@ public class LeafNode<V> extends Node<V> {
    * Constructs a new LeafNode with location, value.
    *
    * @param location The location of the node in the tree.
-   * @param value    The value associated with the node.
+   * @param value The value associated with the node.
    */
   public LeafNode(final Bytes location, final V value) {
     super(false, false);
@@ -52,7 +52,7 @@ public class LeafNode<V> extends Node<V> {
    * Constructs a new LeafNode with optional location, value.
    *
    * @param location The location of the node in the tree (Optional).
-   * @param value    The value associated with the node.
+   * @param value The value associated with the node.
    */
   public LeafNode(final Optional<Bytes> location, final V value) {
     this(location, value, Optional.of(value));
@@ -71,7 +71,7 @@ public class LeafNode<V> extends Node<V> {
    * Accepts a visitor for path-based operations on the node.
    *
    * @param visitor The path node visitor.
-   * @param path    The path associated with a node.
+   * @param path The path associated with a node.
    * @return The result of the visitor's operation.
    */
   @Override
@@ -111,8 +111,7 @@ public class LeafNode<V> extends Node<V> {
   }
 
   /**
-   * Get the children of the node. A leaf node does not have children, so this
-   * method throws an
+   * Get the children of the node. A leaf node does not have children, so this method throws an
    * UnsupportedOperationException.
    *
    * @return The list of children nodes (unsupported operation).
@@ -144,7 +143,8 @@ public class LeafNode<V> extends Node<V> {
     if (encodedValue.isPresent()) {
       return encodedValue.get();
     }
-    Bytes encodedVal = getValue().isPresent() ? valueSerializer.apply(getValue().get()) : Bytes.EMPTY;
+    Bytes encodedVal =
+        getValue().isPresent() ? valueSerializer.apply(getValue().get()) : Bytes.EMPTY;
     this.encodedValue = Optional.of(encodedVal);
     return encodedVal;
   }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/LeafNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/LeafNode.java
@@ -18,14 +18,11 @@ package org.hyperledger.besu.ethereum.trie.verkle.node;
 import org.hyperledger.besu.ethereum.trie.verkle.visitor.NodeVisitor;
 import org.hyperledger.besu.ethereum.trie.verkle.visitor.PathNodeVisitor;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.rlp.RLP;
-import org.apache.tuweni.rlp.RLPWriter;
 
 /**
  * Represents a leaf node in the Verkle Trie.
@@ -42,7 +39,7 @@ public class LeafNode<V> extends Node<V> {
    * Constructs a new LeafNode with location, value.
    *
    * @param location The location of the node in the tree.
-   * @param value The value associated with the node.
+   * @param value    The value associated with the node.
    */
   public LeafNode(final Bytes location, final V value) {
     super(false, false);
@@ -55,7 +52,7 @@ public class LeafNode<V> extends Node<V> {
    * Constructs a new LeafNode with optional location, value.
    *
    * @param location The location of the node in the tree (Optional).
-   * @param value The value associated with the node.
+   * @param value    The value associated with the node.
    */
   public LeafNode(final Optional<Bytes> location, final V value) {
     this(location, value, Optional.of(value));
@@ -74,7 +71,7 @@ public class LeafNode<V> extends Node<V> {
    * Accepts a visitor for path-based operations on the node.
    *
    * @param visitor The path node visitor.
-   * @param path The path associated with a node.
+   * @param path    The path associated with a node.
    * @return The result of the visitor's operation.
    */
   @Override
@@ -114,7 +111,8 @@ public class LeafNode<V> extends Node<V> {
   }
 
   /**
-   * Get the children of the node. A leaf node does not have children, so this method throws an
+   * Get the children of the node. A leaf node does not have children, so this
+   * method throws an
    * UnsupportedOperationException.
    *
    * @return The list of children nodes (unsupported operation).
@@ -146,12 +144,9 @@ public class LeafNode<V> extends Node<V> {
     if (encodedValue.isPresent()) {
       return encodedValue.get();
     }
-    Bytes encodedVal =
-        getValue().isPresent() ? valueSerializer.apply(getValue().get()) : Bytes.EMPTY;
-    List<Bytes> values = Arrays.asList(encodedVal);
-    Bytes result = RLP.encodeList(values, RLPWriter::writeValue);
-    this.encodedValue = Optional.of(result);
-    return result;
+    Bytes encodedVal = getValue().isPresent() ? valueSerializer.apply(getValue().get()) : Bytes.EMPTY;
+    this.encodedValue = Optional.of(encodedVal);
+    return encodedVal;
   }
 
   /**

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/Node.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/Node.java
@@ -36,7 +36,9 @@ public abstract class Node<V> {
   public static Bytes32 EMPTY_HASH = Bytes32.ZERO;
 
   /** A constant representing a commitment to NullNodes */
-  public static Bytes EMPTY_COMMITMENT = Bytes.EMPTY;
+  public static Bytes EMPTY_COMMITMENT = Bytes.fromHexString(
+      "0x0000000000000000000000000000000000000000000000000000000000000000"
+          + "0100000000000000000000000000000000000000000000000000000000000000");
 
   Optional<?> previous;
 
@@ -60,7 +62,7 @@ public abstract class Node<V> {
    * Accept a visitor to perform operations on the node based on a provided path.
    *
    * @param visitor The visitor to accept.
-   * @param path The path associated with a node.
+   * @param path    The path associated with a node.
    * @return The result of visitor's operation.
    */
   public abstract Node<V> accept(PathNodeVisitor<V> visitor, Bytes path);
@@ -72,6 +74,24 @@ public abstract class Node<V> {
    * @return The result of the visitor's operation.
    */
   public abstract Node<V> accept(NodeVisitor<V> visitor);
+
+  /**
+   * Should the node be considered Null ?
+   *
+   * @return isNull
+   */
+  public Boolean isNull() {
+    return false;
+  }
+
+  /**
+   * Does the node have an extension path ?
+   *
+   * @return hasExtension
+   */
+  public Boolean hasExtension() {
+    return false;
+  }
 
   /**
    * Get the location of the node.
@@ -130,10 +150,12 @@ public abstract class Node<V> {
   /**
    * Retrieves the previous state of this node, if it exists.
    *
-   * <p>This method is used to obtain the state of the node before the current one.
+   * <p>
+   * This method is used to obtain the state of the node before the current one.
    *
-   * @return An {@link Optional} containing the previous state of this node if it exists; otherwise,
-   *     an empty {@link Optional}.
+   * @return An {@link Optional} containing the previous state of this node if it
+   *         exists; otherwise,
+   *         an empty {@link Optional}.
    */
   public Optional<?> getPrevious() {
     return previous;
@@ -142,10 +164,14 @@ public abstract class Node<V> {
   /**
    * Sets the previous state of this node.
    *
-   * <p>This method allows updating the node's previous state. It is typically used during the
-   * process of node modification to keep a record of the node's state prior to the current changes.
+   * <p>
+   * This method allows updating the node's previous state. It is typically used
+   * during the
+   * process of node modification to keep a record of the node's state prior to
+   * the current changes.
    *
-   * @param previous An {@link Optional} containing the new previous state to be set for this node.
+   * @param previous An {@link Optional} containing the new previous state to be
+   *                 set for this node.
    */
   public void setPrevious(final Optional<?> previous) {
     this.previous = previous;
@@ -195,8 +221,9 @@ public abstract class Node<V> {
   /**
    * Generates DOT representation for the Node.
    *
-   * @param showNullNodes If true, prints NullNodes and NullLeafNodes; if false, prints only unique
-   *     edges.
+   * @param showNullNodes If true, prints NullNodes and NullLeafNodes; if false,
+   *                      prints only unique
+   *                      edges.
    * @return DOT representation of the Node.
    */
   public abstract String toDot(Boolean showNullNodes);
@@ -204,7 +231,8 @@ public abstract class Node<V> {
   /**
    * Generates DOT representation for the Node.
    *
-   * <p>Representation does not contain repeating edges.
+   * <p>
+   * Representation does not contain repeating edges.
    *
    * @return DOT representation of the Node.
    */
@@ -222,9 +250,8 @@ public abstract class Node<V> {
     // Low values have a flag at bit 128.
     return value
         .map(
-            (v) ->
-                Bytes32.rightPad(
-                    Bytes.concatenate(Bytes32.rightPad((Bytes) v).slice(0, 16), Bytes.of(1))))
+            (v) -> Bytes32.rightPad(
+                Bytes.concatenate(Bytes32.rightPad((Bytes) v).slice(0, 16), Bytes.of(1))))
         .orElse(Bytes32.ZERO);
   }
 

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/Node.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/Node.java
@@ -36,9 +36,10 @@ public abstract class Node<V> {
   public static Bytes32 EMPTY_HASH = Bytes32.ZERO;
 
   /** A constant representing a commitment to NullNodes */
-  public static Bytes EMPTY_COMMITMENT = Bytes.fromHexString(
-      "0x0000000000000000000000000000000000000000000000000000000000000000"
-          + "0100000000000000000000000000000000000000000000000000000000000000");
+  public static Bytes EMPTY_COMMITMENT =
+      Bytes.fromHexString(
+          "0x0000000000000000000000000000000000000000000000000000000000000000"
+              + "0100000000000000000000000000000000000000000000000000000000000000");
 
   Optional<?> previous;
 
@@ -62,7 +63,7 @@ public abstract class Node<V> {
    * Accept a visitor to perform operations on the node based on a provided path.
    *
    * @param visitor The visitor to accept.
-   * @param path    The path associated with a node.
+   * @param path The path associated with a node.
    * @return The result of visitor's operation.
    */
   public abstract Node<V> accept(PathNodeVisitor<V> visitor, Bytes path);
@@ -150,12 +151,10 @@ public abstract class Node<V> {
   /**
    * Retrieves the previous state of this node, if it exists.
    *
-   * <p>
-   * This method is used to obtain the state of the node before the current one.
+   * <p>This method is used to obtain the state of the node before the current one.
    *
-   * @return An {@link Optional} containing the previous state of this node if it
-   *         exists; otherwise,
-   *         an empty {@link Optional}.
+   * @return An {@link Optional} containing the previous state of this node if it exists; otherwise,
+   *     an empty {@link Optional}.
    */
   public Optional<?> getPrevious() {
     return previous;
@@ -164,14 +163,10 @@ public abstract class Node<V> {
   /**
    * Sets the previous state of this node.
    *
-   * <p>
-   * This method allows updating the node's previous state. It is typically used
-   * during the
-   * process of node modification to keep a record of the node's state prior to
-   * the current changes.
+   * <p>This method allows updating the node's previous state. It is typically used during the
+   * process of node modification to keep a record of the node's state prior to the current changes.
    *
-   * @param previous An {@link Optional} containing the new previous state to be
-   *                 set for this node.
+   * @param previous An {@link Optional} containing the new previous state to be set for this node.
    */
   public void setPrevious(final Optional<?> previous) {
     this.previous = previous;
@@ -221,9 +216,8 @@ public abstract class Node<V> {
   /**
    * Generates DOT representation for the Node.
    *
-   * @param showNullNodes If true, prints NullNodes and NullLeafNodes; if false,
-   *                      prints only unique
-   *                      edges.
+   * @param showNullNodes If true, prints NullNodes and NullLeafNodes; if false, prints only unique
+   *     edges.
    * @return DOT representation of the Node.
    */
   public abstract String toDot(Boolean showNullNodes);
@@ -231,8 +225,7 @@ public abstract class Node<V> {
   /**
    * Generates DOT representation for the Node.
    *
-   * <p>
-   * Representation does not contain repeating edges.
+   * <p>Representation does not contain repeating edges.
    *
    * @return DOT representation of the Node.
    */
@@ -250,8 +243,9 @@ public abstract class Node<V> {
     // Low values have a flag at bit 128.
     return value
         .map(
-            (v) -> Bytes32.rightPad(
-                Bytes.concatenate(Bytes32.rightPad((Bytes) v).slice(0, 16), Bytes.of(1))))
+            (v) ->
+                Bytes32.rightPad(
+                    Bytes.concatenate(Bytes32.rightPad((Bytes) v).slice(0, 16), Bytes.of(1))))
         .orElse(Bytes32.ZERO);
   }
 

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/NullLeafNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/NullLeafNode.java
@@ -26,11 +26,8 @@ import org.apache.tuweni.bytes.Bytes32;
 /**
  * A special node representing a null or empty node in the Verkle Trie.
  *
- * <p>
- * The `NullNode` class serves as a placeholder for non-existent nodes in the
- * Verkle Trie
- * structure. It implements the Node interface and represents a node that
- * contains no information or
+ * <p>The `NullNode` class serves as a placeholder for non-existent nodes in the Verkle Trie
+ * structure. It implements the Node interface and represents a node that contains no information or
  * value.
  */
 public class NullLeafNode<V> extends Node<V> {
@@ -48,7 +45,7 @@ public class NullLeafNode<V> extends Node<V> {
    * Accepts a visitor for path-based operations on the node.
    *
    * @param visitor The path node visitor.
-   * @param path    The path associated with a node.
+   * @param path The path associated with a node.
    * @return The result of the visitor's operation.
    */
   @Override
@@ -117,11 +114,12 @@ public class NullLeafNode<V> extends Node<V> {
     if (!showRepeatingEdges) {
       return "";
     }
-    String result = getClass().getSimpleName()
-        + getLocation().orElse(Bytes.EMPTY)
-        + " [label=\"NL: "
-        + getLocation().orElse(Bytes.EMPTY)
-        + "\"]\n";
+    String result =
+        getClass().getSimpleName()
+            + getLocation().orElse(Bytes.EMPTY)
+            + " [label=\"NL: "
+            + getLocation().orElse(Bytes.EMPTY)
+            + "\"]\n";
     return result;
   }
 }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/NullLeafNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/NullLeafNode.java
@@ -26,8 +26,11 @@ import org.apache.tuweni.bytes.Bytes32;
 /**
  * A special node representing a null or empty node in the Verkle Trie.
  *
- * <p>The `NullNode` class serves as a placeholder for non-existent nodes in the Verkle Trie
- * structure. It implements the Node interface and represents a node that contains no information or
+ * <p>
+ * The `NullNode` class serves as a placeholder for non-existent nodes in the
+ * Verkle Trie
+ * structure. It implements the Node interface and represents a node that
+ * contains no information or
  * value.
  */
 public class NullLeafNode<V> extends Node<V> {
@@ -40,11 +43,12 @@ public class NullLeafNode<V> extends Node<V> {
     super(false, true);
     this.previous = previousValue;
   }
+
   /**
    * Accepts a visitor for path-based operations on the node.
    *
    * @param visitor The path node visitor.
-   * @param path The path associated with a node.
+   * @param path    The path associated with a node.
    * @return The result of the visitor's operation.
    */
   @Override
@@ -88,6 +92,11 @@ public class NullLeafNode<V> extends Node<V> {
     dirty = true;
   }
 
+  @Override
+  public Boolean isNull() {
+    return true;
+  }
+
   /**
    * Get a string representation of the `NullNode`.
    *
@@ -108,12 +117,11 @@ public class NullLeafNode<V> extends Node<V> {
     if (!showRepeatingEdges) {
       return "";
     }
-    String result =
-        getClass().getSimpleName()
-            + getLocation().orElse(Bytes.EMPTY)
-            + " [label=\"NL: "
-            + getLocation().orElse(Bytes.EMPTY)
-            + "\"]\n";
+    String result = getClass().getSimpleName()
+        + getLocation().orElse(Bytes.EMPTY)
+        + " [label=\"NL: "
+        + getLocation().orElse(Bytes.EMPTY)
+        + "\"]\n";
     return result;
   }
 }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/NullNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/NullNode.java
@@ -26,8 +26,11 @@ import org.apache.tuweni.bytes.Bytes32;
 /**
  * A special node representing a null or empty node in the Verkle Trie.
  *
- * <p>The `NullNode` class serves as a placeholder for non-existent nodes in the Verkle Trie
- * structure. It implements the Node interface and represents a node that contains no information or
+ * <p>
+ * The `NullNode` class serves as a placeholder for non-existent nodes in the
+ * Verkle Trie
+ * structure. It implements the Node interface and represents a node that
+ * contains no information or
  * value.
  */
 public class NullNode<V> extends Node<V> {
@@ -40,7 +43,7 @@ public class NullNode<V> extends Node<V> {
    * Accepts a visitor for path-based operations on the node.
    *
    * @param visitor The path node visitor.
-   * @param path The path associated with a node.
+   * @param path    The path associated with a node.
    * @return The result of the visitor's operation.
    */
   @Override
@@ -84,6 +87,11 @@ public class NullNode<V> extends Node<V> {
     dirty = true;
   }
 
+  @Override
+  public Boolean isNull() {
+    return true;
+  }
+
   /**
    * Get a string representation of the `NullNode`.
    *
@@ -104,12 +112,11 @@ public class NullNode<V> extends Node<V> {
     if (!showRepeatingEdges) {
       return "";
     }
-    String result =
-        getClass().getSimpleName()
-            + getLocation().orElse(Bytes.EMPTY)
-            + " [label=\"NL: "
-            + getLocation().orElse(Bytes.EMPTY)
-            + "\"]\n";
+    String result = getClass().getSimpleName()
+        + getLocation().orElse(Bytes.EMPTY)
+        + " [label=\"NL: "
+        + getLocation().orElse(Bytes.EMPTY)
+        + "\"]\n";
     return result;
   }
 }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/NullNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/NullNode.java
@@ -26,11 +26,8 @@ import org.apache.tuweni.bytes.Bytes32;
 /**
  * A special node representing a null or empty node in the Verkle Trie.
  *
- * <p>
- * The `NullNode` class serves as a placeholder for non-existent nodes in the
- * Verkle Trie
- * structure. It implements the Node interface and represents a node that
- * contains no information or
+ * <p>The `NullNode` class serves as a placeholder for non-existent nodes in the Verkle Trie
+ * structure. It implements the Node interface and represents a node that contains no information or
  * value.
  */
 public class NullNode<V> extends Node<V> {
@@ -43,7 +40,7 @@ public class NullNode<V> extends Node<V> {
    * Accepts a visitor for path-based operations on the node.
    *
    * @param visitor The path node visitor.
-   * @param path    The path associated with a node.
+   * @param path The path associated with a node.
    * @return The result of the visitor's operation.
    */
   @Override
@@ -112,11 +109,12 @@ public class NullNode<V> extends Node<V> {
     if (!showRepeatingEdges) {
       return "";
     }
-    String result = getClass().getSimpleName()
-        + getLocation().orElse(Bytes.EMPTY)
-        + " [label=\"NL: "
-        + getLocation().orElse(Bytes.EMPTY)
-        + "\"]\n";
+    String result =
+        getClass().getSimpleName()
+            + getLocation().orElse(Bytes.EMPTY)
+            + " [label=\"NL: "
+            + getLocation().orElse(Bytes.EMPTY)
+            + "\"]\n";
     return result;
   }
 }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StemNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StemNode.java
@@ -28,9 +28,7 @@ import org.apache.tuweni.bytes.Bytes32;
 /**
  * Represents a stem node in the Verkle Trie.
  *
- * <p>
- * StemNodes are nodes storing the stem of the key, and is the root of the
- * suffix to value trie.
+ * <p>StemNodes are nodes storing the stem of the key, and is the root of the suffix to value trie.
  *
  * @param <V> The type of the node's value.
  */
@@ -46,15 +44,15 @@ public class StemNode<V> extends BranchNode<V> {
   /**
    * Constructs a new StemNode with non-optional parameters.
    *
-   * @param location        The location in the tree.
-   * @param stem            Node's stem.
-   * @param hash            Node's vector commitment's hash.
-   * @param commitment      Node's vector commitment.
-   * @param leftHash        Hash of vector commitment to left values.
-   * @param leftCommitment  Vector commitment to left values.
-   * @param rightHash       Hash of vector commitment to right values.
+   * @param location The location in the tree.
+   * @param stem Node's stem.
+   * @param hash Node's vector commitment's hash.
+   * @param commitment Node's vector commitment.
+   * @param leftHash Hash of vector commitment to left values.
+   * @param leftCommitment Vector commitment to left values.
+   * @param rightHash Hash of vector commitment to right values.
    * @param rightCommitment Vector commitment to right values.
-   * @param children        The list of children nodes.
+   * @param children The list of children nodes.
    */
   public StemNode(
       final Bytes location,
@@ -78,15 +76,15 @@ public class StemNode<V> extends BranchNode<V> {
   /**
    * Constructs a new StemNode with optional parameters.
    *
-   * @param location        Optional location in the tree.
-   * @param stem            Node's stem.
-   * @param hash            Optional node's vector commitment's hash.
-   * @param commitment      Optional node's vector commitment.
-   * @param leftHash        Optional hash of vector commitment to left values.
-   * @param leftCommitment  Optional vector commitment to left values.
-   * @param rightHash       Optional hash of vector commitment to right values.
+   * @param location Optional location in the tree.
+   * @param stem Node's stem.
+   * @param hash Optional node's vector commitment's hash.
+   * @param commitment Optional node's vector commitment.
+   * @param leftHash Optional hash of vector commitment to left values.
+   * @param leftCommitment Optional vector commitment to left values.
+   * @param rightHash Optional hash of vector commitment to right values.
    * @param rightCommitment Optional vector commitment to right values.
-   * @param children        The list of children nodes.
+   * @param children The list of children nodes.
    */
   public StemNode(
       final Optional<Bytes> location,
@@ -112,7 +110,7 @@ public class StemNode<V> extends BranchNode<V> {
    * Constructs a new BranchNode with non-optional parameters.
    *
    * @param location The location in the tree.
-   * @param stem     Node's stem.
+   * @param stem Node's stem.
    */
   public StemNode(final Bytes location, final Bytes stem) {
     super(location);
@@ -133,7 +131,7 @@ public class StemNode<V> extends BranchNode<V> {
    * Accepts a visitor for path-based operations on the node.
    *
    * @param visitor The path node visitor.
-   * @param path    The path associated with a node.
+   * @param path The path associated with a node.
    * @return The result of the visitor's operation.
    */
   @Override
@@ -218,25 +216,26 @@ public class StemNode<V> extends BranchNode<V> {
    * @return StemNode with new location.
    */
   public StemNode<V> replaceLocation(final Bytes location) {
-    StemNode<V> vStemNode = new StemNode<>(
-        Optional.of(location),
-        stem,
-        getHash(),
-        Optional.empty(),
-        getCommitment(),
-        leftHash,
-        leftCommitment,
-        rightHash,
-        rightCommitment,
-        getChildren());
+    StemNode<V> vStemNode =
+        new StemNode<>(
+            Optional.of(location),
+            stem,
+            getHash(),
+            Optional.empty(),
+            getCommitment(),
+            leftHash,
+            leftCommitment,
+            rightHash,
+            rightCommitment,
+            getChildren());
     return vStemNode;
   }
 
   /**
    * Creates a new node by replacing all its commitments
    *
-   * @param hash      Node's vector commitment hash
-   * @param leftHash  Node's left vector commitment hash
+   * @param hash Node's vector commitment hash
+   * @param leftHash Node's left vector commitment hash
    * @param rightHash Node's right vector commitment hash
    * @return StemNode with new commitments.
    */
@@ -311,26 +310,28 @@ public class StemNode<V> extends BranchNode<V> {
 
   @Override
   public String toDot(Boolean showNullNodes) {
-    StringBuilder result = new StringBuilder()
-        .append(getClass().getSimpleName())
-        .append(getLocation().orElse(Bytes.EMPTY))
-        .append(" [label=\"S: ")
-        .append(getLocation().orElse(Bytes.EMPTY))
-        .append("\nStem: ")
-        .append(getStem())
-        .append("\nLeftCommitment: ")
-        .append(getLeftCommitment().orElse(Bytes32.ZERO))
-        .append("\nRightCommitment: ")
-        .append(getRightCommitment().orElse(Bytes32.ZERO))
-        .append("\"]\n");
+    StringBuilder result =
+        new StringBuilder()
+            .append(getClass().getSimpleName())
+            .append(getLocation().orElse(Bytes.EMPTY))
+            .append(" [label=\"S: ")
+            .append(getLocation().orElse(Bytes.EMPTY))
+            .append("\nStem: ")
+            .append(getStem())
+            .append("\nLeftCommitment: ")
+            .append(getLeftCommitment().orElse(Bytes32.ZERO))
+            .append("\nRightCommitment: ")
+            .append(getRightCommitment().orElse(Bytes32.ZERO))
+            .append("\"]\n");
 
     for (Node<V> child : getChildren()) {
-      String edgeString = getClass().getSimpleName()
-          + getLocation().orElse(Bytes.EMPTY)
-          + " -> "
-          + child.getClass().getSimpleName()
-          + child.getLocation().orElse(Bytes.EMPTY)
-          + "\n";
+      String edgeString =
+          getClass().getSimpleName()
+              + getLocation().orElse(Bytes.EMPTY)
+              + " -> "
+              + child.getClass().getSimpleName()
+              + child.getLocation().orElse(Bytes.EMPTY)
+              + "\n";
 
       if (showNullNodes || !result.toString().contains(edgeString)) {
         result.append(edgeString);

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StemNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StemNode.java
@@ -18,19 +18,19 @@ package org.hyperledger.besu.ethereum.trie.verkle.node;
 import org.hyperledger.besu.ethereum.trie.verkle.visitor.NodeVisitor;
 import org.hyperledger.besu.ethereum.trie.verkle.visitor.PathNodeVisitor;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.rlp.RLP;
-import org.apache.tuweni.rlp.RLPWriter;
 
 /**
  * Represents a stem node in the Verkle Trie.
  *
- * <p>StemNodes are nodes storing the stem of the key, and is the root of the suffix to value trie.
+ * <p>
+ * StemNodes are nodes storing the stem of the key, and is the root of the
+ * suffix to value trie.
  *
  * @param <V> The type of the node's value.
  */
@@ -46,15 +46,15 @@ public class StemNode<V> extends BranchNode<V> {
   /**
    * Constructs a new StemNode with non-optional parameters.
    *
-   * @param location The location in the tree.
-   * @param stem Node's stem.
-   * @param hash Node's vector commitment's hash.
-   * @param commitment Node's vector commitment.
-   * @param leftHash Hash of vector commitment to left values.
-   * @param leftCommitment Vector commitment to left values.
-   * @param rightHash Hash of vector commitment to right values.
+   * @param location        The location in the tree.
+   * @param stem            Node's stem.
+   * @param hash            Node's vector commitment's hash.
+   * @param commitment      Node's vector commitment.
+   * @param leftHash        Hash of vector commitment to left values.
+   * @param leftCommitment  Vector commitment to left values.
+   * @param rightHash       Hash of vector commitment to right values.
    * @param rightCommitment Vector commitment to right values.
-   * @param children The list of children nodes.
+   * @param children        The list of children nodes.
    */
   public StemNode(
       final Bytes location,
@@ -78,15 +78,15 @@ public class StemNode<V> extends BranchNode<V> {
   /**
    * Constructs a new StemNode with optional parameters.
    *
-   * @param location Optional location in the tree.
-   * @param stem Node's stem.
-   * @param hash Optional node's vector commitment's hash.
-   * @param commitment Optional node's vector commitment.
-   * @param leftHash Optional hash of vector commitment to left values.
-   * @param leftCommitment Optional vector commitment to left values.
-   * @param rightHash Optional hash of vector commitment to right values.
+   * @param location        Optional location in the tree.
+   * @param stem            Node's stem.
+   * @param hash            Optional node's vector commitment's hash.
+   * @param commitment      Optional node's vector commitment.
+   * @param leftHash        Optional hash of vector commitment to left values.
+   * @param leftCommitment  Optional vector commitment to left values.
+   * @param rightHash       Optional hash of vector commitment to right values.
    * @param rightCommitment Optional vector commitment to right values.
-   * @param children The list of children nodes.
+   * @param children        The list of children nodes.
    */
   public StemNode(
       final Optional<Bytes> location,
@@ -112,7 +112,7 @@ public class StemNode<V> extends BranchNode<V> {
    * Constructs a new BranchNode with non-optional parameters.
    *
    * @param location The location in the tree.
-   * @param stem Node's stem.
+   * @param stem     Node's stem.
    */
   public StemNode(final Bytes location, final Bytes stem) {
     super(location);
@@ -133,7 +133,7 @@ public class StemNode<V> extends BranchNode<V> {
    * Accepts a visitor for path-based operations on the node.
    *
    * @param visitor The path node visitor.
-   * @param path The path associated with a node.
+   * @param path    The path associated with a node.
    * @return The result of the visitor's operation.
    */
   @Override
@@ -159,6 +159,11 @@ public class StemNode<V> extends BranchNode<V> {
    */
   public Bytes getStem() {
     return stem;
+  }
+
+  @Override
+  public Boolean hasExtension() {
+    return true;
   }
 
   /**
@@ -213,26 +218,25 @@ public class StemNode<V> extends BranchNode<V> {
    * @return StemNode with new location.
    */
   public StemNode<V> replaceLocation(final Bytes location) {
-    StemNode<V> vStemNode =
-        new StemNode<>(
-            Optional.of(location),
-            stem,
-            getHash(),
-            Optional.empty(),
-            getCommitment(),
-            leftHash,
-            leftCommitment,
-            rightHash,
-            rightCommitment,
-            getChildren());
+    StemNode<V> vStemNode = new StemNode<>(
+        Optional.of(location),
+        stem,
+        getHash(),
+        Optional.empty(),
+        getCommitment(),
+        leftHash,
+        leftCommitment,
+        rightHash,
+        rightCommitment,
+        getChildren());
     return vStemNode;
   }
 
   /**
    * Creates a new node by replacing all its commitments
    *
-   * @param hash Node's vector commitment hash
-   * @param leftHash Node's left vector commitment hash
+   * @param hash      Node's vector commitment hash
+   * @param leftHash  Node's left vector commitment hash
    * @param rightHash Node's right vector commitment hash
    * @return StemNode with new commitments.
    */
@@ -262,16 +266,21 @@ public class StemNode<V> extends BranchNode<V> {
     if (encodedValue.isPresent()) {
       return encodedValue.get();
     }
-    List<Bytes> values =
-        Arrays.asList(
-            getStem(),
-            (Bytes) getHash().get(),
-            getCommitment().get(),
-            (Bytes) getLeftHash().get(),
-            getLeftCommitment().get(),
-            (Bytes) getRightHash().get(),
-            getRightCommitment().get());
-    Bytes result = RLP.encodeList(values, RLPWriter::writeValue);
+    List<Bytes> values = new ArrayList<>();
+    values.add(Bytes.of(2));
+    values.add(stem);
+    values.add(getCommitment().get());
+    values.add(getLeftCommitment().get());
+    values.add(getRightCommitment().get());
+    values.add((Bytes) getLeftHash().get());
+    values.add((Bytes) getRightHash().get());
+    values.add(getNullBitmap());
+    for (Node<V> child : getChildren()) {
+      if (!child.isNull()) {
+        values.add(child.getEncodedValue());
+      }
+    }
+    Bytes result = Bytes.concatenate(values);
     this.encodedValue = Optional.of(result);
     return result;
   }
@@ -302,28 +311,26 @@ public class StemNode<V> extends BranchNode<V> {
 
   @Override
   public String toDot(Boolean showNullNodes) {
-    StringBuilder result =
-        new StringBuilder()
-            .append(getClass().getSimpleName())
-            .append(getLocation().orElse(Bytes.EMPTY))
-            .append(" [label=\"S: ")
-            .append(getLocation().orElse(Bytes.EMPTY))
-            .append("\nStem: ")
-            .append(getStem())
-            .append("\nLeftCommitment: ")
-            .append(getLeftCommitment().orElse(Bytes32.ZERO))
-            .append("\nRightCommitment: ")
-            .append(getRightCommitment().orElse(Bytes32.ZERO))
-            .append("\"]\n");
+    StringBuilder result = new StringBuilder()
+        .append(getClass().getSimpleName())
+        .append(getLocation().orElse(Bytes.EMPTY))
+        .append(" [label=\"S: ")
+        .append(getLocation().orElse(Bytes.EMPTY))
+        .append("\nStem: ")
+        .append(getStem())
+        .append("\nLeftCommitment: ")
+        .append(getLeftCommitment().orElse(Bytes32.ZERO))
+        .append("\nRightCommitment: ")
+        .append(getRightCommitment().orElse(Bytes32.ZERO))
+        .append("\"]\n");
 
     for (Node<V> child : getChildren()) {
-      String edgeString =
-          getClass().getSimpleName()
-              + getLocation().orElse(Bytes.EMPTY)
-              + " -> "
-              + child.getClass().getSimpleName()
-              + child.getLocation().orElse(Bytes.EMPTY)
-              + "\n";
+      String edgeString = getClass().getSimpleName()
+          + getLocation().orElse(Bytes.EMPTY)
+          + " -> "
+          + child.getClass().getSimpleName()
+          + child.getLocation().orElse(Bytes.EMPTY)
+          + "\n";
 
       if (showNullNodes || !result.toString().contains(edgeString)) {
         result.append(edgeString);

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StoredNode.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/node/StoredNode.java
@@ -28,8 +28,7 @@ import org.apache.tuweni.bytes.Bytes32;
 /**
  * Represents a regular node that can possibly be stored in storage.
  *
- * <p>
- * StoredNodes wrap regular nodes and loads them lazily from storage as needed.
+ * <p>StoredNodes wrap regular nodes and loads them lazily from storage as needed.
  *
  * @param <V> The type of the node's value.
  */
@@ -43,7 +42,7 @@ public class StoredNode<V> extends Node<V> {
    * Constructs a new StoredNode at location.
    *
    * @param nodeFactory The node factory for creating nodes from storage.
-   * @param location    The location in the tree.
+   * @param location The location in the tree.
    */
   public StoredNode(final NodeFactory<V> nodeFactory, final Bytes location) {
     super(false, true);
@@ -57,8 +56,8 @@ public class StoredNode<V> extends Node<V> {
    * Constructs a new StoredNode at location.
    *
    * @param nodeFactory The node factory for creating nodes from storage.
-   * @param location    The location in the tree.
-   * @param hash        The hash value of the node.
+   * @param location The location in the tree.
+   * @param hash The hash value of the node.
    */
   public StoredNode(final NodeFactory<V> nodeFactory, final Bytes location, final Bytes32 hash) {
     super(false, true);
@@ -72,7 +71,7 @@ public class StoredNode<V> extends Node<V> {
    * Accept a visitor to perform operations on the node based on a provided path.
    *
    * @param visitor The visitor to accept.
-   * @param path    The path associated with a node.
+   * @param path The path associated with a node.
    * @return The result of visitor's operation.
    */
   @Override
@@ -184,11 +183,12 @@ public class StoredNode<V> extends Node<V> {
    */
   @Override
   public String toDot(Boolean showNullNodes) {
-    String result = getClass().getSimpleName()
-        + getLocation().orElse(Bytes.EMPTY)
-        + " [label=\"SD: "
-        + getLocation().orElse(Bytes.EMPTY)
-        + "\"]\n";
+    String result =
+        getClass().getSimpleName()
+            + getLocation().orElse(Bytes.EMPTY)
+            + " [label=\"SD: "
+            + getLocation().orElse(Bytes.EMPTY)
+            + "\"]\n";
     return result;
   }
 

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/CommitVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/CommitVisitor.java
@@ -28,7 +28,8 @@ import org.apache.tuweni.bytes.Bytes;
 /**
  * A visitor class responsible for committing changes to nodes in a Trie tree.
  *
- * <p>It iterates through the nodes and stores the changes in the Trie structure.
+ * <p>
+ * It iterates through the nodes and stores the changes in the Trie structure.
  *
  * @param <V> The type of node values.
  */
@@ -40,7 +41,8 @@ public class CommitVisitor<V> implements PathNodeVisitor<V> {
   /**
    * Constructs a CommitVisitor with a provided NodeUpdater.
    *
-   * @param nodeUpdater The NodeUpdater used to store changes in the Trie structure.
+   * @param nodeUpdater The NodeUpdater used to store changes in the Trie
+   *                    structure.
    */
   public CommitVisitor(final NodeUpdater nodeUpdater) {
     this.nodeUpdater = nodeUpdater;
@@ -50,7 +52,7 @@ public class CommitVisitor<V> implements PathNodeVisitor<V> {
    * Visits a InternalNode to commit any changes in the node and its children.
    *
    * @param internalNode The internalNode being visited.
-   * @param location The location in the Trie tree.
+   * @param location     The location in the Trie tree.
    * @return The visited internalNode.
    */
   @Override
@@ -110,13 +112,13 @@ public class CommitVisitor<V> implements PathNodeVisitor<V> {
    */
   @Override
   public Node<V> visit(final LeafNode<V> leafNode, final Bytes location) {
-    if (leafNode.isPersisted()) {
-      return leafNode;
-    }
-    if (leafNode.isDirty()) {
-      throw new RuntimeException("cannot persist dirty node");
-    }
-    nodeUpdater.store(location, null, leafNode.getEncodedValue());
+    // if (leafNode.isPersisted()) {
+    // return leafNode;
+    // }
+    // if (leafNode.isDirty()) {
+    // throw new RuntimeException("cannot persist dirty node");
+    // }
+    // nodeUpdater.store(location, null, leafNode.getEncodedValue());
     leafNode.markPersisted();
     return leafNode;
   }
@@ -137,7 +139,7 @@ public class CommitVisitor<V> implements PathNodeVisitor<V> {
    * Visits a NullLeafNode, indicating no changes to commit.
    *
    * @param nullLeafNode The NullLeafNode being visited.
-   * @param location The location in the Trie tree.
+   * @param location     The location in the Trie tree.
    * @return The NullLeafNode indicating no changes.
    */
   @Override

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/CommitVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/CommitVisitor.java
@@ -28,8 +28,7 @@ import org.apache.tuweni.bytes.Bytes;
 /**
  * A visitor class responsible for committing changes to nodes in a Trie tree.
  *
- * <p>
- * It iterates through the nodes and stores the changes in the Trie structure.
+ * <p>It iterates through the nodes and stores the changes in the Trie structure.
  *
  * @param <V> The type of node values.
  */
@@ -41,8 +40,7 @@ public class CommitVisitor<V> implements PathNodeVisitor<V> {
   /**
    * Constructs a CommitVisitor with a provided NodeUpdater.
    *
-   * @param nodeUpdater The NodeUpdater used to store changes in the Trie
-   *                    structure.
+   * @param nodeUpdater The NodeUpdater used to store changes in the Trie structure.
    */
   public CommitVisitor(final NodeUpdater nodeUpdater) {
     this.nodeUpdater = nodeUpdater;
@@ -52,7 +50,7 @@ public class CommitVisitor<V> implements PathNodeVisitor<V> {
    * Visits a InternalNode to commit any changes in the node and its children.
    *
    * @param internalNode The internalNode being visited.
-   * @param location     The location in the Trie tree.
+   * @param location The location in the Trie tree.
    * @return The visited internalNode.
    */
   @Override
@@ -139,7 +137,7 @@ public class CommitVisitor<V> implements PathNodeVisitor<V> {
    * Visits a NullLeafNode, indicating no changes to commit.
    *
    * @param nullLeafNode The NullLeafNode being visited.
-   * @param location     The location in the Trie tree.
+   * @param location The location in the Trie tree.
    * @return The NullLeafNode indicating no changes.
    */
   @Override

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/HashVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/HashVisitor.java
@@ -32,8 +32,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 /**
- * A visitor class for hashing operations on Verkle Trie nodes. The batched
- * version is recommended
+ * A visitor class for hashing operations on Verkle Trie nodes. The batched version is recommended
  * for better performance
  *
  * @see VerkleTrieBatchHasher
@@ -43,12 +42,11 @@ public class HashVisitor<V extends Bytes> implements PathNodeVisitor<V> {
   Hasher hasher = new PedersenHasher();
 
   /**
-   * Visits a internal node, computes its hash, and returns a new internal node
-   * with the updated
+   * Visits a internal node, computes its hash, and returns a new internal node with the updated
    * hash.
    *
    * @param internalNode The internal node to visit.
-   * @param location     The location associated with the internal node.
+   * @param location The location associated with the internal node.
    * @return A new internal node with the updated hash.
    */
   @Override
@@ -81,8 +79,7 @@ public class HashVisitor<V extends Bytes> implements PathNodeVisitor<V> {
   }
 
   /**
-   * Visits a branch node, computes its hash, and returns a new branch node with
-   * the updated hash.
+   * Visits a branch node, computes its hash, and returns a new branch node with the updated hash.
    *
    * @param stemNode The branch node to visit.
    * @param location The location associated with the branch node.
@@ -121,10 +118,9 @@ public class HashVisitor<V extends Bytes> implements PathNodeVisitor<V> {
     hashes[3] = hasher.hash(rightCommitment);
     Bytes commitment = hasher.commit(hashes);
     final Bytes32 hash = hasher.hash(commitment);
-    StemNode<V> vStemNode = stemNode.replaceHash(
-        hash, commitment,
-        hashes[2], leftCommitment,
-        hashes[3], rightCommitment);
+    StemNode<V> vStemNode =
+        stemNode.replaceHash(
+            hash, commitment, hashes[2], leftCommitment, hashes[3], rightCommitment);
     vStemNode.markClean();
     return vStemNode;
   }

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/HashVisitor.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/visitor/HashVisitor.java
@@ -32,7 +32,8 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 /**
- * A visitor class for hashing operations on Verkle Trie nodes. The batched version is recommended
+ * A visitor class for hashing operations on Verkle Trie nodes. The batched
+ * version is recommended
  * for better performance
  *
  * @see VerkleTrieBatchHasher
@@ -42,11 +43,12 @@ public class HashVisitor<V extends Bytes> implements PathNodeVisitor<V> {
   Hasher hasher = new PedersenHasher();
 
   /**
-   * Visits a internal node, computes its hash, and returns a new internal node with the updated
+   * Visits a internal node, computes its hash, and returns a new internal node
+   * with the updated
    * hash.
    *
    * @param internalNode The internal node to visit.
-   * @param location The location associated with the internal node.
+   * @param location     The location associated with the internal node.
    * @return A new internal node with the updated hash.
    */
   @Override
@@ -67,18 +69,20 @@ public class HashVisitor<V extends Bytes> implements PathNodeVisitor<V> {
       hashes[i] = updatedChild.getHash().get();
     }
     final Bytes32 hash;
+    final Bytes commitment = hasher.commit(hashes);
     if (location.isEmpty()) {
-      hash = hasher.commitRoot(hashes);
+      hash = hasher.compress(commitment);
     } else {
-      hash = hasher.hash(hasher.commit(hashes));
+      hash = hasher.hash(commitment);
     }
-    final Node<V> vNode = internalNode.replaceHash(hash, hash); // commitment should be different
+    final Node<V> vNode = internalNode.replaceHash(hash, commitment);
     vNode.markClean();
     return vNode;
   }
 
   /**
-   * Visits a branch node, computes its hash, and returns a new branch node with the updated hash.
+   * Visits a branch node, computes its hash, and returns a new branch node with
+   * the updated hash.
    *
    * @param stemNode The branch node to visit.
    * @param location The location associated with the branch node.
@@ -109,15 +113,18 @@ public class HashVisitor<V extends Bytes> implements PathNodeVisitor<V> {
       rightValues[2 * i - size] = getLowValue(child.getValue());
       rightValues[2 * i + 1 - size] = getHighValue(child.getValue());
     }
+    Bytes leftCommitment = hasher.commit(leftValues);
+    Bytes rightCommitment = hasher.commit(rightValues);
     hashes[0] = Bytes32.rightPad(Bytes.of(1)); // extension marker
     hashes[1] = Bytes32.rightPad(stemNode.getStem());
-    hashes[2] = hasher.hash(hasher.commit(leftValues));
-    hashes[3] = hasher.hash(hasher.commit(rightValues));
-    final Bytes32 hash = hasher.hash(hasher.commit(hashes));
-    StemNode<V> vStemNode =
-        stemNode.replaceHash(
-            hash, hash, hashes[2], hashes[2], hashes[3],
-            hashes[3]); // commitment should be different
+    hashes[2] = hasher.hash(leftCommitment);
+    hashes[3] = hasher.hash(rightCommitment);
+    Bytes commitment = hasher.commit(hashes);
+    final Bytes32 hash = hasher.hash(commitment);
+    StemNode<V> vStemNode = stemNode.replaceHash(
+        hash, commitment,
+        hashes[2], leftCommitment,
+        hashes[3], rightCommitment);
     vStemNode.markClean();
     return vStemNode;
   }

--- a/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/StoredBatchedVerkleTrieTest.java
+++ b/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/StoredBatchedVerkleTrieTest.java
@@ -35,13 +35,14 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
+    StoredNodeFactory<Bytes32> nodeFactory =
+        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
   }
 
@@ -50,16 +51,19 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
-    Bytes32 key = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
-    Bytes32 value = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+    StoredNodeFactory<Bytes32> nodeFactory =
+        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    Bytes32 key =
+        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    Bytes32 value =
+        Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
     trie.put(key, value);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key).orElse(null)).as("Retrieved value").isEqualTo(value);
   }
@@ -69,19 +73,24 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
-    Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
-    Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key2 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddee00");
-    Bytes32 value2 = Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
+    StoredNodeFactory<Bytes32> nodeFactory =
+        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    Bytes32 key1 =
+        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    Bytes32 value1 =
+        Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key2 =
+        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddee00");
+    Bytes32 value2 =
+        Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
     trie.put(key1, value1);
     trie.put(key2, value2);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
@@ -92,19 +101,24 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
-    Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
-    Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key2 = Bytes32.fromHexString("0xff112233445566778899aabbccddeeff00112233445566778899aabbccddee00");
-    Bytes32 value2 = Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
+    StoredNodeFactory<Bytes32> nodeFactory =
+        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    Bytes32 key1 =
+        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    Bytes32 value1 =
+        Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key2 =
+        Bytes32.fromHexString("0xff112233445566778899aabbccddeeff00112233445566778899aabbccddee00");
+    Bytes32 value2 =
+        Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
     trie.put(key1, value1);
     trie.put(key2, value2);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
@@ -115,19 +129,24 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
-    Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
-    Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key2 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
-    Bytes32 value2 = Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
+    StoredNodeFactory<Bytes32> nodeFactory =
+        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    Bytes32 key1 =
+        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    Bytes32 value1 =
+        Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key2 =
+        Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
+    Bytes32 value2 =
+        Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
     trie.put(key1, value1);
     trie.put(key2, value2);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
@@ -138,22 +157,29 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
-    Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
-    Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key2 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
-    Bytes32 value2 = Bytes32.fromHexString("0x0200000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key3 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddff");
-    Bytes32 value3 = Bytes32.fromHexString("0x0300000000000000000000000000000000000000000000000000000000000000");
+    StoredNodeFactory<Bytes32> nodeFactory =
+        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    Bytes32 key1 =
+        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    Bytes32 value1 =
+        Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key2 =
+        Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
+    Bytes32 value2 =
+        Bytes32.fromHexString("0x0200000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key3 =
+        Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddff");
+    Bytes32 value3 =
+        Bytes32.fromHexString("0x0300000000000000000000000000000000000000000000000000000000000000");
     trie.put(key1, value1);
     trie.put(key2, value2);
     trie.put(key3, value3);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
@@ -165,22 +191,29 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
-    Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
-    Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key2 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
-    Bytes32 value2 = Bytes32.fromHexString("0x0200000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key3 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddff");
-    Bytes32 value3 = Bytes32.fromHexString("0x0300000000000000000000000000000000000000000000000000000000000000");
+    StoredNodeFactory<Bytes32> nodeFactory =
+        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    Bytes32 key1 =
+        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    Bytes32 value1 =
+        Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key2 =
+        Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
+    Bytes32 value2 =
+        Bytes32.fromHexString("0x0200000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key3 =
+        Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddff");
+    Bytes32 value3 =
+        Bytes32.fromHexString("0x0300000000000000000000000000000000000000000000000000000000000000");
     trie.put(key1, value1);
     trie.put(key2, value2);
     trie.put(key3, value3);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
@@ -192,26 +225,38 @@ public class StoredBatchedVerkleTrieTest {
     final Map<Bytes, Bytes> map = new HashMap<>();
 
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredBatchedVerkleTrie<Bytes, Bytes> trie = new StoredBatchedVerkleTrie<>(
-        batchProcessor,
-        new StoredNodeFactory<>(
-            (location, hash) -> Optional.ofNullable(map.get(location)), value -> value));
+    StoredBatchedVerkleTrie<Bytes, Bytes> trie =
+        new StoredBatchedVerkleTrie<>(
+            batchProcessor,
+            new StoredNodeFactory<>(
+                (location, hash) -> Optional.ofNullable(map.get(location)), value -> value));
 
     assertThat(trie.getRootHash()).isEqualTo(Bytes32.ZERO);
-    Bytes32 key0 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45641");
-    Bytes32 value0 = Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000001");
-    Bytes32 key1 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45601");
-    Bytes32 value1 = Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000001");
-    Bytes32 key2 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45602");
+    Bytes32 key0 =
+        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45641");
+    Bytes32 value0 =
+        Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000001");
+    Bytes32 key1 =
+        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45601");
+    Bytes32 value1 =
+        Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000001");
+    Bytes32 key2 =
+        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45602");
     Bytes32 value2 = Bytes32.fromHexString("0x01");
-    Bytes32 key3 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45600");
+    Bytes32 key3 =
+        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45600");
     Bytes32 value3 = Bytes32.fromHexString("0x00");
-    Bytes32 key4 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45603");
-    Bytes32 value4 = Bytes32.fromHexString("0xf84a97f1f0a956e738abd85c2e0a5026f8874e3ec09c8f012159dfeeaab2b156");
-    Bytes32 key5 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45604");
+    Bytes32 key4 =
+        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45603");
+    Bytes32 value4 =
+        Bytes32.fromHexString("0xf84a97f1f0a956e738abd85c2e0a5026f8874e3ec09c8f012159dfeeaab2b156");
+    Bytes32 key5 =
+        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45604");
     Bytes32 value5 = Bytes32.fromHexString("0x03");
-    Bytes32 key6 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45680");
-    Bytes32 value6 = Bytes32.fromHexString("0x0000010200000000000000000000000000000000000000000000000000000000");
+    Bytes32 key6 =
+        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45680");
+    Bytes32 value6 =
+        Bytes32.fromHexString("0x0000010200000000000000000000000000000000000000000000000000000000");
     trie.put(key0, value0);
     trie.put(key1, value1);
     trie.put(key2, value2);
@@ -227,10 +272,11 @@ public class StoredBatchedVerkleTrieTest {
             map.put(location, value);
           }
         });
-    StoredBatchedVerkleTrie<Bytes, Bytes> trie2 = new StoredBatchedVerkleTrie<>(
-        batchProcessor,
-        new StoredNodeFactory<>(
-            (location, hash) -> Optional.ofNullable(map.get(location)), value -> value));
+    StoredBatchedVerkleTrie<Bytes, Bytes> trie2 =
+        new StoredBatchedVerkleTrie<>(
+            batchProcessor,
+            new StoredNodeFactory<>(
+                (location, hash) -> Optional.ofNullable(map.get(location)), value -> value));
     assertThat(trie2.getRootHash()).isEqualTo(trie.getRootHash());
     trie2.remove(key0);
     trie2.remove(key4);
@@ -247,9 +293,10 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
+    StoredNodeFactory<Bytes32> nodeFactory =
+        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
 
     trie.put(
         Bytes32.fromHexString("0x1123356d04d4bd662ba38c44cbd79d4108521284d80327fa533e0baab1af9fff"),
@@ -258,8 +305,8 @@ public class StoredBatchedVerkleTrieTest {
     trie.commit(nodeUpdater);
     Bytes32 expectedRootHash = trie.getRootHash();
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie2 = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie2 =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
     trie2.put(
         Bytes32.fromHexString("0x117b67dd491b9e11d9cde84ef3c02f11ddee9e18284969dc7d496d43c300e500"),
         Bytes32.fromHexString(
@@ -267,8 +314,8 @@ public class StoredBatchedVerkleTrieTest {
 
     trie2.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie3 = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
-        nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie3 =
+        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
     trie3.remove(
         Bytes32.fromHexString(
             "0x117b67dd491b9e11d9cde84ef3c02f11ddee9e18284969dc7d496d43c300e500"));

--- a/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/StoredBatchedVerkleTrieTest.java
+++ b/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/StoredBatchedVerkleTrieTest.java
@@ -35,14 +35,13 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory =
-        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
   }
 
@@ -51,19 +50,16 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory =
-        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
-    Bytes32 key =
-        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
-    Bytes32 value =
-        Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
+    Bytes32 key = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    Bytes32 value = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
     trie.put(key, value);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key).orElse(null)).as("Retrieved value").isEqualTo(value);
   }
@@ -73,24 +69,19 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory =
-        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
-    Bytes32 key1 =
-        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
-    Bytes32 value1 =
-        Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key2 =
-        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddee00");
-    Bytes32 value2 =
-        Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
+    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
+    Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key2 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddee00");
+    Bytes32 value2 = Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
     trie.put(key1, value1);
     trie.put(key2, value2);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
@@ -101,24 +92,19 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory =
-        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
-    Bytes32 key1 =
-        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
-    Bytes32 value1 =
-        Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key2 =
-        Bytes32.fromHexString("0xff112233445566778899aabbccddeeff00112233445566778899aabbccddee00");
-    Bytes32 value2 =
-        Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
+    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
+    Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key2 = Bytes32.fromHexString("0xff112233445566778899aabbccddeeff00112233445566778899aabbccddee00");
+    Bytes32 value2 = Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
     trie.put(key1, value1);
     trie.put(key2, value2);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
@@ -129,24 +115,19 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory =
-        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
-    Bytes32 key1 =
-        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
-    Bytes32 value1 =
-        Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key2 =
-        Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
-    Bytes32 value2 =
-        Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
+    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
+    Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key2 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
+    Bytes32 value2 = Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
     trie.put(key1, value1);
     trie.put(key2, value2);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
@@ -157,29 +138,22 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory =
-        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
-    Bytes32 key1 =
-        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
-    Bytes32 value1 =
-        Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key2 =
-        Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
-    Bytes32 value2 =
-        Bytes32.fromHexString("0x0200000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key3 =
-        Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddff");
-    Bytes32 value3 =
-        Bytes32.fromHexString("0x0300000000000000000000000000000000000000000000000000000000000000");
+    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
+    Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key2 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
+    Bytes32 value2 = Bytes32.fromHexString("0x0200000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key3 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddff");
+    Bytes32 value3 = Bytes32.fromHexString("0x0300000000000000000000000000000000000000000000000000000000000000");
     trie.put(key1, value1);
     trie.put(key2, value2);
     trie.put(key3, value3);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
@@ -191,29 +165,22 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory =
-        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
-    Bytes32 key1 =
-        Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
-    Bytes32 value1 =
-        Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key2 =
-        Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
-    Bytes32 value2 =
-        Bytes32.fromHexString("0x0200000000000000000000000000000000000000000000000000000000000000");
-    Bytes32 key3 =
-        Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddff");
-    Bytes32 value3 =
-        Bytes32.fromHexString("0x0300000000000000000000000000000000000000000000000000000000000000");
+    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
+    Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key2 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
+    Bytes32 value2 = Bytes32.fromHexString("0x0200000000000000000000000000000000000000000000000000000000000000");
+    Bytes32 key3 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddff");
+    Bytes32 value3 = Bytes32.fromHexString("0x0300000000000000000000000000000000000000000000000000000000000000");
     trie.put(key1, value1);
     trie.put(key2, value2);
     trie.put(key3, value3);
     trie.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> storedTrie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
     assertThat(storedTrie.getRootHash()).isEqualTo(trie.getRootHash());
     assertThat(storedTrie.get(key1).orElse(null)).isEqualTo(value1);
     assertThat(storedTrie.get(key2).orElse(null)).isEqualTo(value2);
@@ -225,38 +192,26 @@ public class StoredBatchedVerkleTrieTest {
     final Map<Bytes, Bytes> map = new HashMap<>();
 
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredBatchedVerkleTrie<Bytes, Bytes> trie =
-        new StoredBatchedVerkleTrie<>(
-            batchProcessor,
-            new StoredNodeFactory<>(
-                (location, hash) -> Optional.ofNullable(map.get(location)), value -> value));
+    StoredBatchedVerkleTrie<Bytes, Bytes> trie = new StoredBatchedVerkleTrie<>(
+        batchProcessor,
+        new StoredNodeFactory<>(
+            (location, hash) -> Optional.ofNullable(map.get(location)), value -> value));
 
     assertThat(trie.getRootHash()).isEqualTo(Bytes32.ZERO);
-    Bytes32 key0 =
-        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45641");
-    Bytes32 value0 =
-        Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000001");
-    Bytes32 key1 =
-        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45601");
-    Bytes32 value1 =
-        Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000001");
-    Bytes32 key2 =
-        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45602");
+    Bytes32 key0 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45641");
+    Bytes32 value0 = Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000001");
+    Bytes32 key1 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45601");
+    Bytes32 value1 = Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000001");
+    Bytes32 key2 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45602");
     Bytes32 value2 = Bytes32.fromHexString("0x01");
-    Bytes32 key3 =
-        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45600");
+    Bytes32 key3 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45600");
     Bytes32 value3 = Bytes32.fromHexString("0x00");
-    Bytes32 key4 =
-        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45603");
-    Bytes32 value4 =
-        Bytes32.fromHexString("0xf84a97f1f0a956e738abd85c2e0a5026f8874e3ec09c8f012159dfeeaab2b156");
-    Bytes32 key5 =
-        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45604");
+    Bytes32 key4 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45603");
+    Bytes32 value4 = Bytes32.fromHexString("0xf84a97f1f0a956e738abd85c2e0a5026f8874e3ec09c8f012159dfeeaab2b156");
+    Bytes32 key5 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45604");
     Bytes32 value5 = Bytes32.fromHexString("0x03");
-    Bytes32 key6 =
-        Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45680");
-    Bytes32 value6 =
-        Bytes32.fromHexString("0x0000010200000000000000000000000000000000000000000000000000000000");
+    Bytes32 key6 = Bytes32.fromHexString("0x1e4abaeaa58259f4784e086ddbaa74a9d3975efb2e4380595f0eed5692c45680");
+    Bytes32 value6 = Bytes32.fromHexString("0x0000010200000000000000000000000000000000000000000000000000000000");
     trie.put(key0, value0);
     trie.put(key1, value1);
     trie.put(key2, value2);
@@ -272,11 +227,10 @@ public class StoredBatchedVerkleTrieTest {
             map.put(location, value);
           }
         });
-    StoredBatchedVerkleTrie<Bytes, Bytes> trie2 =
-        new StoredBatchedVerkleTrie<>(
-            batchProcessor,
-            new StoredNodeFactory<>(
-                (location, hash) -> Optional.ofNullable(map.get(location)), value -> value));
+    StoredBatchedVerkleTrie<Bytes, Bytes> trie2 = new StoredBatchedVerkleTrie<>(
+        batchProcessor,
+        new StoredNodeFactory<>(
+            (location, hash) -> Optional.ofNullable(map.get(location)), value -> value));
     assertThat(trie2.getRootHash()).isEqualTo(trie.getRootHash());
     trie2.remove(key0);
     trie2.remove(key4);
@@ -293,10 +247,9 @@ public class StoredBatchedVerkleTrieTest {
     NodeUpdaterMock nodeUpdater = new NodeUpdaterMock();
     NodeLoaderMock nodeLoader = new NodeLoaderMock(nodeUpdater.storage);
     VerkleTrieBatchHasher batchProcessor = new VerkleTrieBatchHasher();
-    StoredNodeFactory<Bytes32> nodeFactory =
-        new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    StoredNodeFactory<Bytes32> nodeFactory = new StoredNodeFactory<>(nodeLoader, value -> (Bytes32) value);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
 
     trie.put(
         Bytes32.fromHexString("0x1123356d04d4bd662ba38c44cbd79d4108521284d80327fa533e0baab1af9fff"),
@@ -305,8 +258,8 @@ public class StoredBatchedVerkleTrieTest {
     trie.commit(nodeUpdater);
     Bytes32 expectedRootHash = trie.getRootHash();
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie2 =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie2 = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
     trie2.put(
         Bytes32.fromHexString("0x117b67dd491b9e11d9cde84ef3c02f11ddee9e18284969dc7d496d43c300e500"),
         Bytes32.fromHexString(
@@ -314,8 +267,8 @@ public class StoredBatchedVerkleTrieTest {
 
     trie2.commit(nodeUpdater);
 
-    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie3 =
-        new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor, nodeFactory);
+    StoredBatchedVerkleTrie<Bytes32, Bytes32> trie3 = new StoredBatchedVerkleTrie<Bytes32, Bytes32>(batchProcessor,
+        nodeFactory);
     trie3.remove(
         Bytes32.fromHexString(
             "0x117b67dd491b9e11d9cde84ef3c02f11ddee9e18284969dc7d496d43c300e500"));


### PR DESCRIPTION
## PR description

- Adding children's nullity bitmap to StoredNodes in order to avoid reading/seeking non-existent keys from database.
- Adding children's hashes/values to storage to batch reads.

Not included but possible next steps: 

- avoid storing null commitments/hashes.
- explore whether storing hashes and/or uncompressed commitments versus only compressed commitments is a good trade-off between storage and compute.