### PR TITLE
Add SuffixTreeEncoder for encoding BasicDataLeaf values

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
-version=0.0.1-SNAPSHOT
-
+version=0.0.2
 org.gradle.welcome=never

--- a/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/util/SuffixTreeEncoder.java
+++ b/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/util/SuffixTreeEncoder.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Hyperledger Besu Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.trie.verkle.util;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class SuffixTreeEncoder {
+  private static final int VERSION_OFFSET = 0;
+  private static final int CODE_SIZE_OFFSET = 5;
+  private static final int NONCE_OFFSET = 8;
+  private static final int BALANCE_OFFSET = 16;
+  private static final Bytes32 VERSION_VALUE_MASK;
+  private static final Bytes32 CODE_SIZE_VALUE_MASK;
+  private static final Bytes32 NONCE_VALUE_MASK;
+  private static final Bytes32 BALANCE_VALUE_MASK;
+
+  static {
+    VERSION_VALUE_MASK =
+        encodeIntoBasicDataLeaf(Bytes.repeat((byte) 0xff, 1), VERSION_OFFSET).not();
+    CODE_SIZE_VALUE_MASK =
+        encodeIntoBasicDataLeaf(Bytes.repeat((byte) 0xff, 3), CODE_SIZE_OFFSET).not();
+    NONCE_VALUE_MASK = encodeIntoBasicDataLeaf(Bytes.repeat((byte) 0xff, 8), NONCE_OFFSET).not();
+    BALANCE_VALUE_MASK =
+        encodeIntoBasicDataLeaf(Bytes.repeat((byte) 0xff, 16), BALANCE_OFFSET).not();
+  }
+
+  public static Bytes32 eraseVersion(final Bytes32 value) {
+    return value.and(VERSION_VALUE_MASK);
+  }
+
+  public static Bytes32 eraseCodeSize(final Bytes32 value) {
+    return value.and(CODE_SIZE_VALUE_MASK);
+  }
+
+  public static Bytes32 eraseNonce(final Bytes32 value) {
+    return value.and(NONCE_VALUE_MASK);
+  }
+
+  public static Bytes32 eraseBalance(final Bytes32 value) {
+    return value.and(BALANCE_VALUE_MASK);
+  }
+
+  public static Bytes32 addVersionIntoValue(final Bytes32 value, final Bytes version) {
+    return value.or(encodeIntoBasicDataLeaf(version, VERSION_OFFSET));
+  }
+
+  public static Bytes32 addCodeSizeIntoValue(final Bytes32 value, final Bytes codeSize) {
+    return value.or(encodeIntoBasicDataLeaf(codeSize, CODE_SIZE_OFFSET));
+  }
+
+  public static Bytes32 addNonceIntoValue(final Bytes32 value, final Bytes nonce) {
+    return value.or(encodeIntoBasicDataLeaf(nonce, NONCE_OFFSET));
+  }
+
+  public static Bytes32 addBalanceIntoValue(final Bytes32 value, final Bytes balance) {
+    return value.or(encodeIntoBasicDataLeaf(balance, BALANCE_OFFSET));
+  }
+
+  /**
+   * Encoding of a field into the BasicDataLeaf 32 byte value, using Little-Endian order.
+   *
+   * @param value to encode into a 32 byte value
+   * @param byteShift byte position of `value` within the final 32 byte value
+   * @throws IllegalArgumentException if `value` does not fit within 32 bytes after being encoded
+   * @return encoded BasicDataLeaf value
+   */
+  public static Bytes32 encodeIntoBasicDataLeaf(final Bytes value, final int byteShift) {
+    Bytes32 value32Bytes = Bytes32.leftPad(value);
+    if (byteShift == 0) {
+      return value32Bytes;
+    } else if (byteShift < 0) {
+      throw new IllegalArgumentException(
+          "invalid byteShift " + byteShift + " must be greater than zero");
+    } else if (value32Bytes.numberOfLeadingZeroBytes() < byteShift) {
+      int valueSizeBytes = 32 - value32Bytes.numberOfLeadingZeroBytes() + byteShift;
+      throw new IllegalArgumentException(
+          "value must be 32 bytes but becomes "
+              + valueSizeBytes
+              + " bytes with byteShift "
+              + byteShift);
+    }
+    return value32Bytes.shiftLeft(byteShift * 8);
+  }
+}

--- a/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/util/SuffixTreeEncoderTest.java
+++ b/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/util/SuffixTreeEncoderTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Hyperledger Besu Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.trie.verkle.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class SuffixTreeEncoderTest {
+
+  public static Stream<Arguments> valuesStart() {
+    return Stream.of(
+        Arguments.of(Bytes32.ZERO, Bytes32.ZERO),
+        Arguments.of(
+            Bytes.of(0xff),
+            Bytes32.fromHexString(
+                "0x00000000000000000000000000000000000000000000000000000000000000FF")),
+        Arguments.of(
+            Bytes32.leftPad(Bytes.of(0xff)),
+            Bytes32.fromHexString(
+                "0x00000000000000000000000000000000000000000000000000000000000000FF")),
+        Arguments.of(
+            Bytes.repeat((byte) 0xff, 12),
+            Bytes32.fromHexString(
+                "0x0000000000000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF")),
+        Arguments.of(
+            Bytes.fromHexString("0xadef"),
+            Bytes32.fromHexString(
+                "0x000000000000000000000000000000000000000000000000000000000000ADEF")),
+        Arguments.of(
+            Bytes.fromHexString("0x1123d3"),
+            Bytes32.fromHexString(
+                "0x00000000000000000000000000000000000000000000000000000000001123D3")));
+  }
+
+  public static Stream<Arguments> valuesMiddle() {
+    return Stream.of(
+        Arguments.of(Bytes32.ZERO, Bytes32.ZERO),
+        Arguments.of(
+            Bytes.of(0xff),
+            Bytes32.fromHexString(
+                "0x00000000000000000000000000000000FF000000000000000000000000000000")),
+        Arguments.of(
+            Bytes.repeat((byte) 0xff, 12),
+            Bytes32.fromHexString(
+                "0x00000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000")),
+        Arguments.of(
+            Bytes.fromHexString("0xadef"),
+            Bytes32.fromHexString(
+                "0x000000000000000000000000000000ADEF000000000000000000000000000000")),
+        Arguments.of(
+            Bytes.fromHexString("0x1123d3"),
+            Bytes32.fromHexString(
+                "0x0000000000000000000000000000001123D30000000000000000000000000000")));
+  }
+
+  public static Stream<Arguments> valuesEnd() {
+    return Stream.of(
+        Arguments.of(Bytes32.ZERO, Bytes32.ZERO),
+        Arguments.of(
+            Bytes.repeat((byte) 0xff, 12),
+            Bytes32.fromHexString(
+                "0xFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000")),
+        Arguments.of(
+            Bytes.of(0xff),
+            Bytes32.fromHexString(
+                "0xFF00000000000000000000000000000000000000000000000000000000000000")),
+        Arguments.of(
+            Bytes.fromHexString("0xadef"),
+            Bytes32.fromHexString(
+                "0xADEF000000000000000000000000000000000000000000000000000000000000")),
+        Arguments.of(
+            Bytes.fromHexString("0x1123d3"),
+            Bytes32.fromHexString(
+                "0x1123D30000000000000000000000000000000000000000000000000000000000")));
+  }
+
+  public static Stream<Arguments> valuesOutOfRange() {
+    return Stream.of(
+        Arguments.of(Bytes.repeat((byte) 0xff, 12), 25),
+        Arguments.of(Bytes.of(0xff), 32),
+        Arguments.of(Bytes.fromHexString("0xadef"), 31),
+        Arguments.of(Bytes.fromHexString("0x1123d3"), 30));
+  }
+
+  @ParameterizedTest
+  @MethodSource("valuesStart")
+  void encodeBytesStart(final Bytes value, final Bytes32 expected) {
+    assertEquals(expected, SuffixTreeEncoder.encodeIntoBasicDataLeaf(value, 0));
+  }
+
+  @ParameterizedTest
+  @MethodSource("valuesMiddle")
+  void encodeBytesMiddle(final Bytes value, final Bytes32 expected) {
+    assertEquals(
+        expected, SuffixTreeEncoder.encodeIntoBasicDataLeaf(value, (32 - value.size()) / 2));
+  }
+
+  @ParameterizedTest
+  @MethodSource("valuesEnd")
+  void encodeBytesEnd(final Bytes value, final Bytes32 expected) {
+    assertEquals(expected, SuffixTreeEncoder.encodeIntoBasicDataLeaf(value, 32 - value.size()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("valuesOutOfRange")
+  void encodeBytesOutsideRange(final Bytes value, final int byteShift) {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SuffixTreeEncoder.encodeIntoBasicDataLeaf(value, byteShift));
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->

## PR description
Moving encoder outside of besu as requested during review: https://github.com/hyperledger/besu/pull/7594

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->