### PR TITLE
Fix missing SNAPSHOT prefix from artifact and bump version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.0.2
+version=0.0.3-SNAPSHOT
 org.gradle.welcome=never


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->

## PR description
Fix little issue as I removed that SNAPSHOT suffix from the artifact version and should have kept it. I'm also bumping the version so that we can totally discard `0.0.2` which was a mistake.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->